### PR TITLE
🔒 [security fix] Remove API key exposure from client-side bundle

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,10 +26,6 @@ export default defineConfig(({ mode }) => {
         renderer: {},
       }),
     ],
-    define: {
-      'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-      'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
-    },
     resolve: {
       alias: {
         '@': path.resolve(__dirname, '.'),


### PR DESCRIPTION
This PR fixes a security vulnerability where the Gemini API key was being bundled into the client-side code using Vite's `define` option. 

### 🔍 Analysis
In `vite.config.ts`, the `define` property was used to inject `process.env.API_KEY` and `process.env.GEMINI_API_KEY` into the bundled code:

```typescript
    define: {
      'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
      'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
    },
```

This causes Vite to perform a search-and-replace at build time, hardcoding the actual value of the API key into the distributed JavaScript files.

### 🛡️ Solution
I have removed this `define` block. The application should handle sensitive keys either:
1. In the Electron main process (which has secure access to environment variables).
2. Via a backend proxy.

Since my analysis showed no current usage of these variables in the renderer source code, this change does not break existing functionality but significantly improves security.

### ✅ Verification
- Ran `grep` to ensure no other references to these variables exist in the source code.
- Verified that the `define` block is completely removed from `vite.config.ts`.
- Build and installation were attempted but were restricted by the sandbox environment; however, the fix is a safe configuration-only change.


---
*PR created automatically by Jules for task [17489126573103913088](https://jules.google.com/task/17489126573103913088) started by @seanbud*