### PR TITLE
🔒 Fix insecure server binding in vite.config.ts

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig(({ mode }) => {
     base: './', // Important for Electron to load relative assets
     server: {
       port: 3000,
-      host: '0.0.0.0',
+      host: '127.0.0.1',
     },
     plugins: [
       react(),


### PR DESCRIPTION
🔒 **Security Fix: Insecure Server Binding**

**What:** Updated `vite.config.ts` to bind the development server to `127.0.0.1` instead of `0.0.0.0`.

**Risk:** Binding to `0.0.0.0` exposes the development server to all network interfaces. If the developer is on a public or untrusted network, this could allow unauthorized access to the application during development.

**Solution:** Explicitly setting `host: '127.0.0.1'` ensures the server is only accessible from the local machine (localhost).

**Verification:**
- Verified the configuration change in `vite.config.ts`.
- Ran `npm run build` to confirm the build process remains intact.
- Checked for tests (none found).


---
*PR created automatically by Jules for task [2078463400656852361](https://jules.google.com/task/2078463400656852361) started by @seanbud*