### PR TITLE
🎨 Palette: Add '/' shortcut and improve checkbox accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-14 - Accessible Checkboxes and Keyboard Shortcuts
+**Learning:** Combining non-semantic elements like `div` with `input` for custom checkboxes creates accessibility gaps (missing focus states, roles). Also, users expect standard keyboard shortcuts like `/` for search, but these need visual hints to be discoverable.
+**Action:** Always use semantic `<input type="checkbox">` with `aria-label` for selection states, and include bracketed keyboard hints (e.g., `[/]`) in placeholders when implementing focus shortcuts.

--- a/App.tsx
+++ b/App.tsx
@@ -34,6 +34,7 @@ const App: React.FC = () => {
   const [sidebarWidth, setSidebarWidth] = useState(320);
   const [isResizing, setIsResizing] = useState(false);
   const sidebarRef = useRef<HTMLDivElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   // Context Menu State
   const [contextMenu, setContextMenu] = useState<{
@@ -81,6 +82,18 @@ const App: React.FC = () => {
       window.removeEventListener('mouseup', stopResizing);
     };
   }, [resize, stopResizing]);
+
+  // Keyboard shortcut for focusing filter input
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === '/' && document.activeElement?.tagName !== 'INPUT' && document.activeElement?.tagName !== 'TEXTAREA') {
+        e.preventDefault();
+        searchInputRef.current?.focus();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
 
 
   // Filtering Logic
@@ -300,8 +313,9 @@ const App: React.FC = () => {
           <div className={`p-3 border-b border-gray-200/60 ${sidebarHeaderBg} backdrop-blur-sm flex flex-col gap-3 transition-colors duration-300 shadow-sm z-10`}>
              <div className="relative group">
                <input 
+                 ref={searchInputRef}
                  type="text" 
-                 placeholder="Filter (e.g. *.md, src feature)..."
+                 placeholder="Filter files (e.g. *.md) [/]"
                  value={searchQuery}
                  onChange={(e) => setSearchQuery(e.target.value)}
                  className="w-full pl-2 pr-7 py-1.5 text-xs bg-white border border-gray-200 rounded text-gray-700 placeholder-gray-400 focus:outline-none focus:border-blue-400 focus:ring-2 focus:ring-blue-100 transition-all shadow-sm"
@@ -321,19 +335,13 @@ const App: React.FC = () => {
 
              <div className="flex items-center select-none">
                 <div className="mr-2 flex items-center justify-center">
-                   {allFilteredSelected ? (
-                      <input 
-                        type="checkbox" 
-                        checked={true}
-                        onChange={toggleSelectAll}
-                        className={`h-3.5 w-3.5 border-gray-300 rounded focus:ring-blue-500 cursor-pointer ${isPrincess ? 'accent-pink-500' : 'accent-blue-600'}`}
-                      />
-                   ) : (
-                      <div 
-                         onClick={toggleSelectAll} 
-                         className="h-3.5 w-3.5 rounded-[3px] border border-gray-400/60 bg-white/40 hover:border-blue-400 cursor-pointer"
-                      />
-                   )}
+                   <input
+                     type="checkbox"
+                     checked={allFilteredSelected}
+                     onChange={toggleSelectAll}
+                     aria-label="Select all filtered files"
+                     className={`h-3.5 w-3.5 border-gray-300 rounded focus:ring-blue-500 cursor-pointer ${isPrincess ? 'accent-pink-500' : 'accent-blue-600'}`}
+                   />
                 </div>
                 
                 <div onClick={toggleSelectAll} className="cursor-pointer flex items-baseline truncate">


### PR DESCRIPTION
This PR introduces a micro-UX improvement to the `git-cleanup-princess` application:

💡 **What**:
- Implements a keyboard shortcut (`/`) to quickly focus the file filter input.
- Updates the placeholder text to include `[/]` as a hint.
- Improves the accessibility of the "Select All" checkbox by using a semantic `<input type="checkbox">` with an `aria-label`.

🎯 **Why**:
- Provides a standard, efficient way for power users to filter files.
- Ensures the application is more accessible to screen reader users by removing non-semantic interactive elements.

♿ **Accessibility**:
- Replaced a `div`-based custom checkbox with a native `input[type="checkbox"]`.
- Added `aria-label="Select all filtered files"`.
- Keyboard shortcut logic respects existing focused inputs.

---
*PR created automatically by Jules for task [6209805063700830185](https://jules.google.com/task/6209805063700830185) started by @seanbud*