### PR TITLE
🛡️ Sentinel: Fix API key leak and harden GitHub auth

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-19 - API Key Leak via Vite Define
+**Vulnerability:** Sensitive API keys (GEMINI_API_KEY) were being bundled into the frontend JavaScript via Vite's `define` configuration.
+**Learning:** Even if an environment variable is not explicitly used in the source code, including it in the `define` block of `vite.config.ts` makes it accessible to anyone who inspects the client-side artifacts.
+**Prevention:** Only expose public configuration to the frontend. Manage all secrets in the Electron main process and never use `define` or the `VITE_` prefix for sensitive data.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -10,6 +10,8 @@ const __dirname = path.dirname(__filename);
 let win: BrowserWindow | null;
 const VITE_DEV_SERVER_URL = process.env['VITE_DEV_SERVER_URL'];
 
+const GITHUB_CLIENT_ID = 'Ov23lil6obiLhsHkt1R2';
+
 const TOKEN_PATH = path.join(app.getPath('userData'), 'github-token.bin');
 const RECENT_REPOS_PATH = path.join(app.getPath('userData'), 'recent-repos.json');
 const SETTINGS_PATH = path.join(app.getPath('userData'), 'settings.json');
@@ -254,21 +256,21 @@ app.whenReady().then(() => {
     }
 
     // ─── GitHub Auth IPC ──────────────────────────────────────────
-    ipcMain.handle('github:start-auth', async (_, clientId) => {
+    ipcMain.handle('github:start-auth', async () => {
         const response = await fetch('https://github.com/login/device/code', {
             method: 'POST',
             headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
-            body: JSON.stringify({ client_id: clientId, scope: 'repo,user' })
+            body: JSON.stringify({ client_id: GITHUB_CLIENT_ID, scope: 'repo,user' })
         });
         return response.json();
     });
 
-    ipcMain.handle('github:poll-token', async (_, clientId, deviceCode) => {
+    ipcMain.handle('github:poll-token', async (_, deviceCode) => {
         const response = await fetch('https://github.com/login/oauth/access_token', {
             method: 'POST',
             headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
             body: JSON.stringify({
-                client_id: clientId,
+                client_id: GITHUB_CLIENT_ID,
                 device_code: deviceCode,
                 grant_type: 'urn:ietf:params:oauth:grant-type:device_code'
             })

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -5,8 +5,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.on(channel, (_, data) => callback(data));
     },
     // GitHub Auth
-    githubStartAuth: (clientId: string) => ipcRenderer.invoke('github:start-auth', clientId),
-    githubPollToken: (clientId: string, deviceCode: string) => ipcRenderer.invoke('github:poll-token', clientId, deviceCode),
+    githubStartAuth: () => ipcRenderer.invoke('github:start-auth'),
+    githubPollToken: (deviceCode: string) => ipcRenderer.invoke('github:poll-token', deviceCode),
     githubGetUser: (token?: string) => ipcRenderer.invoke('github:get-user', token),
     githubIsAuthenticated: () => ipcRenderer.invoke('github:is-authenticated'),
     githubSignOut: () => ipcRenderer.invoke('github:sign-out'),

--- a/services/githubAuth.ts
+++ b/services/githubAuth.ts
@@ -1,5 +1,3 @@
-export const GITHUB_CLIENT_ID = 'Ov23lil6obiLhsHkt1R2';
-
 export interface DeviceCodeResponse {
     device_code: string;
     user_code: string;
@@ -21,14 +19,14 @@ export interface AuthTokenResponse {
 export class GitHubAuthClient {
     static async requestDeviceCode(): Promise<DeviceCodeResponse> {
         // @ts-ignore
-        return window.electronAPI.githubStartAuth(GITHUB_CLIENT_ID);
+        return window.electronAPI.githubStartAuth();
     }
 
     static async pollForToken(deviceCode: string, interval: number): Promise<string | null> {
         return new Promise((resolve) => {
             const poll = async () => {
                 // @ts-ignore
-                const token = await window.electronAPI.githubPollToken(GITHUB_CLIENT_ID, deviceCode);
+                const token = await window.electronAPI.githubPollToken(deviceCode);
                 if (token) {
                     resolve(token);
                 } else {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,10 +26,6 @@ export default defineConfig(({ mode }) => {
         renderer: {},
       }),
     ],
-    define: {
-      'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-      'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
-    },
     resolve: {
       alias: {
         '@': path.resolve(__dirname, '.'),


### PR DESCRIPTION
Identified and fixed a critical security issue where sensitive API keys were being bundled into the frontend code. Additionally hardened the GitHub authentication flow by moving the Client ID to the Electron main process and removing it from the IPC interface, preventing potential client-side manipulation of the OAuth flow. All changes are under 50 lines and verified through the build process.

---
*PR created automatically by Jules for task [12084753010715183265](https://jules.google.com/task/12084753010715183265) started by @seanbud*