### PR TITLE
🛡️ Sentinel: Fix command injection in Git IPC handlers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Sensitive API keys (GEMINI_API_KEY) were being bundled into the frontend JavaScript via Vite's `define` configuration.
 **Learning:** Even if an environment variable is not explicitly used in the source code, including it in the `define` block of `vite.config.ts` makes it accessible to anyone who inspects the client-side artifacts.
 **Prevention:** Only expose public configuration to the frontend. Manage all secrets in the Electron main process and never use `define` or the `VITE_` prefix for sensitive data.
+
+## 2026-03-05 - Command Injection via Electron IPC
+**Vulnerability:** Passing raw command strings from the renderer to the main process and executing them via `execSync` allowed arbitrary shell command injection.
+**Learning:** Even with seemingly safe strings, shell meta-characters and user-controlled inputs (like filenames or branch names) can be exploited to execute malicious code.
+**Prevention:** Always use argument arrays with `execFile` or `execFileSync` to bypass the shell. Never allow the renderer to specify the executable; use dedicated handlers for specific OS actions like opening editors or terminals. Validate URL protocols for `shell.openExternal`.

--- a/App.tsx
+++ b/App.tsx
@@ -109,10 +109,8 @@ const App: React.FC = () => {
   // ─── Auth Init ─────────────────────────────────────────────────
   useEffect(() => {
     const initAuth = async () => {
-      // @ts-ignore
       const isAuthenticated = await window.electronAPI.githubIsAuthenticated();
       if (isAuthenticated) {
-        // @ts-ignore
         const user = await window.electronAPI.githubGetUser();
         git.setGithubUser(user);
       } else {
@@ -132,7 +130,6 @@ const App: React.FC = () => {
       ? { color: '#fff0f6', symbolColor: '#742a2a' }
       : { color: '#eef5ff', symbolColor: '#1e293b' };
 
-    // @ts-ignore
     window.electronAPI.setTitleBarOverlay?.(overlayOptions);
   };
 
@@ -375,7 +372,6 @@ const App: React.FC = () => {
           }
         }}
         onSignOut={async () => {
-          // @ts-ignore
           await window.electronAPI.githubSignOut();
           git.setGithubUser(null);
           setIsSignInOpen(true);

--- a/components/OptionsModal.tsx
+++ b/components/OptionsModal.tsx
@@ -235,16 +235,13 @@ const OptionsModal: React.FC<OptionsModalProps> = ({
                             onClick={async () => {
                                 // Persist to git config
                                 if (localGitConfig.name !== gitConfig.name) {
-                                    // @ts-ignore
-                                    await window.electronAPI.gitCmd(`git config user.name "${localGitConfig.name}"`);
+                                    await window.electronAPI.gitCmd('config', 'user.name', localGitConfig.name);
                                 }
                                 if (localGitConfig.email !== gitConfig.email) {
-                                    // @ts-ignore
-                                    await window.electronAPI.gitCmd(`git config user.email "${localGitConfig.email}"`);
+                                    await window.electronAPI.gitCmd('config', 'user.email', localGitConfig.email);
                                 }
                                 if (localGitConfig.defaultBranch !== gitConfig.defaultBranch) {
-                                    // @ts-ignore
-                                    await window.electronAPI.gitCmd(`git config init.defaultBranch "${localGitConfig.defaultBranch}"`);
+                                    await window.electronAPI.gitCmd('config', 'init.defaultBranch', localGitConfig.defaultBranch);
                                 }
                                 onSave(localGitConfig, localAppSettings);
                                 setShowSaved(true);

--- a/components/SignInModal.tsx
+++ b/components/SignInModal.tsx
@@ -78,7 +78,6 @@ const SignInModal: React.FC<SignInModalProps> = ({ isOpen, mode, onSuccess }) =>
                 launchConfetti(isPrincess);
 
                 // Now fetch user info
-                // @ts-ignore
                 const user = await window.electronAPI.githubGetUser(token);
                 onSuccess(user);
             }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -11,7 +11,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     githubIsAuthenticated: () => ipcRenderer.invoke('github:is-authenticated'),
     githubSignOut: () => ipcRenderer.invoke('github:sign-out'),
     // Git CLI
-    gitCmd: (cmd: string) => ipcRenderer.invoke('git:cmd', cmd),
+    gitCmd: (...args: string[]) => ipcRenderer.invoke('git:cmd', args),
     gitConfigGet: (key: string) => ipcRenderer.invoke('git:config-get', key),
     // Repository Management
     openDirectory: () => ipcRenderer.invoke('dialog:open-directory'),
@@ -22,6 +22,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     openExternal: (url: string) => ipcRenderer.invoke('shell:open-external', url),
     showItemInFolder: (path: string) => ipcRenderer.invoke('shell:open-path', path),
     openDirectoryPath: (path: string) => ipcRenderer.invoke('shell:open-directory', path),
+    openEditor: (path: string) => ipcRenderer.invoke('shell:open-editor', path),
+    openTerminal: () => ipcRenderer.invoke('shell:open-terminal'),
     trashFile: (path: string) => ipcRenderer.invoke('shell:trash-item', path),
     getCwd: () => ipcRenderer.invoke('app:get-cwd'),
     // File Preview

--- a/global.d.ts
+++ b/global.d.ts
@@ -4,7 +4,44 @@ declare global {
   interface Window {
     electronAPI: {
       on: (channel: string, callback: (data: any) => void) => void;
-      resolvePath: (path: string) => Promise<string>;
+      // GitHub Auth
+      githubStartAuth: () => Promise<any>;
+      githubPollToken: (deviceCode: string) => Promise<string | null>;
+      githubGetUser: (token?: string) => Promise<any>;
+      githubIsAuthenticated: () => Promise<boolean>;
+      githubSignOut: () => Promise<void>;
+      // Git CLI
+      gitCmd: (...args: string[]) => Promise<{ stdout: string; stderr?: string; success: boolean }>;
+      gitConfigGet: (key: string) => Promise<string>;
+      // Repository Management
+      openDirectory: () => Promise<{ path: string } | { error: string } | null>;
+      getRecentRepos: () => Promise<string[]>;
+      addRecentRepo: (path: string) => Promise<void>;
+      switchRepo: (path: string) => Promise<{ success: boolean; error?: string }>;
+      // Shell
+      openExternal: (url: string) => Promise<void>;
+      showItemInFolder: (path: string) => Promise<void>;
+      openDirectoryPath: (path: string) => Promise<void>;
+      openEditor: (path: string) => Promise<{ success: boolean; error?: string }>;
+      openTerminal: () => Promise<{ success: boolean; error?: string }>;
+      trashFile: (path: string) => Promise<{ success: boolean; error?: string }>;
+      getCwd: () => Promise<string>;
+      // File Preview
+      readFileBase64: (path: string) => Promise<{ success: boolean; dataUri?: string; size?: number; error?: string }>;
+      getGitFileBase64: (path: string) => Promise<{ success: boolean; dataUri?: string; size?: number; error?: string }>;
+      // Auto-Update
+      checkForUpdate: () => Promise<any>;
+      downloadUpdate: () => Promise<any>;
+      installUpdate: () => Promise<any>;
+      // Window Controls
+      toggleFullScreen: () => Promise<void>;
+      toggleDevTools: () => Promise<void>;
+      newWindow: () => Promise<void>;
+      getAppVersion: () => Promise<string>;
+      getAppSettings: () => Promise<any>;
+      saveAppSettings: (settings: any) => Promise<void>;
+      setTitleBarOverlay?: (options: { color: string; symbolColor: string }) => Promise<void>;
+      platform: string;
     };
   }
 }

--- a/hooks/useContextMenu.ts
+++ b/hooks/useContextMenu.ts
@@ -47,8 +47,7 @@ export function useContextMenu({ currentBranch, onOpenGithub, onDiscardChanges, 
             items.push({
                 label: 'Open with External Editor',
                 action: () => {
-                    // @ts-ignore
-                    window.electronAPI.gitCmd(`${appSettings.externalEditor || 'code'} "${payload.path}"`);
+                    window.electronAPI.openEditor(payload.path);
                 }
             });
             items.push({
@@ -92,10 +91,7 @@ export function useContextMenu({ currentBranch, onOpenGithub, onDiscardChanges, 
             items.push({
                 label: 'Open in Terminal',
                 action: () => {
-                    const shellCmd = appSettings.shell || 'powershell';
-                    const fullCmd = shellCmd === 'powershell' ? 'start powershell' : (shellCmd === 'cmd' ? 'start cmd' : shellCmd);
-                    // @ts-ignore
-                    window.electronAPI.gitCmd(fullCmd);
+                    window.electronAPI.openTerminal();
                 }
             });
         } else if (type === 'BRANCH') {

--- a/hooks/useGitState.ts
+++ b/hooks/useGitState.ts
@@ -104,7 +104,6 @@ export function useGitState(): UseGitStateReturn {
 
     const loadRecentRepos = useCallback(async () => {
         try {
-            // @ts-ignore
             const repos = await window.electronAPI.getRecentRepos();
             setRecentRepos(repos || []);
         } catch { }
@@ -163,7 +162,6 @@ export function useGitState(): UseGitStateReturn {
     }, []);
 
     const handleChangeRepo = useCallback(async (repoPath: string) => {
-        // @ts-ignore
         const result = await window.electronAPI.switchRepo(repoPath);
         if (result.success) {
             setComparisonBranch(''); // Reset for new repo
@@ -173,9 +171,8 @@ export function useGitState(): UseGitStateReturn {
     }, [refreshGitState, loadRecentRepos]);
 
     const handleOpenRepo = useCallback(async () => {
-        // @ts-ignore
         const result = await window.electronAPI.openDirectory();
-        if (result && !result.error) {
+        if (result && !('error' in result) && result !== null) {
             await refreshGitState();
             await loadRecentRepos();
         }
@@ -184,7 +181,6 @@ export function useGitState(): UseGitStateReturn {
     const handleOpenGithub = useCallback(async () => {
         const url = await GitService.getRemoteUrl();
         if (url) {
-            // @ts-ignore
             window.electronAPI.openExternal(url);
         }
     }, []);

--- a/services/githubAuth.ts
+++ b/services/githubAuth.ts
@@ -18,14 +18,12 @@ export interface AuthTokenResponse {
 
 export class GitHubAuthClient {
     static async requestDeviceCode(): Promise<DeviceCodeResponse> {
-        // @ts-ignore
         return window.electronAPI.githubStartAuth();
     }
 
     static async pollForToken(deviceCode: string, interval: number): Promise<string | null> {
         return new Promise((resolve) => {
             const poll = async () => {
-                // @ts-ignore
                 const token = await window.electronAPI.githubPollToken(deviceCode);
                 if (token) {
                     resolve(token);


### PR DESCRIPTION
This PR addresses a critical command injection vulnerability in the Electron IPC layer. Previously, the renderer could send arbitrary shell command strings to the main process, which were executed directly via \`execSync\`. This allowed any malicious or compromised renderer code (or even just malicious filenames in a repository) to execute arbitrary code on the host system.

The fix involves:
1. **Hardening IPC Handlers:** All git-related handlers now use \`execFileSync\` with argument arrays, which bypasses the shell and prevents injection.
2. **Dedicated OS Handlers:** Generic command execution for opening editors or terminals has been replaced with dedicated, safe IPC handlers (\`shell:open-editor\`, \`shell:open-terminal\`).
3. **URL Validation:** \`shell.openExternal\` now validates that URLs use \`https:\` or \`mailto:\` protocols.
4. **Type Safety:** The \`window.electronAPI\` is now fully typed in \`global.d.ts\`, allowing for the removal of numerous unsafe \`@ts-ignore\` comments throughout the renderer.

Verification:
- \`pnpm exec tsc\` confirms no type errors.
- \`pnpm build\` confirms a successful production build.
- Frontend verified via Playwright screenshot.


---
*PR created automatically by Jules for task [11394210083436770922](https://jules.google.com/task/11394210083436770922) started by @seanbud*