### PR TITLE
🎨 Palette: Informative File List and Enhanced Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -21,3 +21,7 @@
 ## 2025-05-25 - [Accessibility for Toggle Buttons in Diff View]
 **Learning:** Using semantic `<button type="button">` with `aria-expanded` and `aria-label` for chunk headers and context expansion in diff views ensures that complex code-viewing interfaces are navigable for screen reader and keyboard users.
 **Action:** Always use buttons for toggles in the diff view and include `focus:ring-inset` to provide clear focus indicators without layout shifts.
+
+## 2025-05-26 - [Line Change Metadata for Informed Auditing]
+**Learning:** Displaying line addition and removal counts directly in the file list provides immediate context for the magnitude of changes, allowing users to prioritize their audit. This metadata should be styled for high contrast in both selected and unselected states.
+**Action:** Include summarized change statistics (e.g., `+10 -5`) in file list items when available to improve information density and decision-making speed.

--- a/components/FileList.tsx
+++ b/components/FileList.tsx
@@ -90,7 +90,13 @@ const FileListItem: React.FC<FileListItemProps> = React.memo(({
       </div>
 
       <div className="flex-1 min-w-0 mr-2">
-        {renderPath(file.path)}
+        <div className="flex items-center gap-2">
+          {renderPath(file.path)}
+          <div className={`flex space-x-1 text-[9px] font-bold shrink-0 ${isSelected ? 'text-white/80' : ''}`}>
+            <span className={isSelected ? '' : 'text-green-600'}>+{file.linesAdded}</span>
+            <span className={isSelected ? '' : 'text-red-500'}>-{file.linesRemoved}</span>
+          </div>
+        </div>
         {file.commitMessage && (
           <div className={`text-[10px] truncate mt-0.5 ${isSelected ? 'text-white/70' : 'text-gray-400'}`}>
             {file.commitMessage}

--- a/components/ProductTitleBar.tsx
+++ b/components/ProductTitleBar.tsx
@@ -58,6 +58,7 @@ const ProductTitleBar: React.FC<ProductTitleBarProps> = ({ mode, onToggleTheme }
         <button
           onClick={() => { onToggleTheme(); audioService.play('sparkle'); }}
           className={`px-3 py-1 rounded-full text-xs font-bold transition-all active:scale-95 shadow-sm border ${isPrincess ? 'bg-pink-100 hover:bg-pink-200 text-pink-700 border-pink-200' : 'bg-blue-100 hover:bg-blue-200 text-blue-700 border-blue-200'}`}
+          aria-label={isPrincess ? 'Switch to Prince Mode' : 'Switch to Princess Mode'}
           title={isPrincess ? 'Switch to Prince Mode' : 'Switch to Princess Mode'}
         >
           {isPrincess ? '👑 Princess' : '⚔️ Prince'}

--- a/components/RepoHeader.tsx
+++ b/components/RepoHeader.tsx
@@ -101,6 +101,8 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
       >
         <button
           onClick={(e) => handleDropdownClick(e, 'REPO')}
+          aria-label="Select repository"
+          title="Select repository"
           className={`flex items-center space-x-2 px-3 py-1.5 rounded-full text-xs font-bold transition-all border shadow-sm active:scale-95 ${repoButtonBg}`}
         >
           <Icons.GitCommit className="w-3.5 h-3.5 opacity-70" />
@@ -137,13 +139,16 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
           onContextMenu={(e) => { e.stopPropagation(); onContextMenu(e, 'BRANCH'); }}
         >
           {/* Branch Name Dropdown Trigger */}
-          <div
+          <button
+            type="button"
             onClick={(e) => handleDropdownClick(e, 'BRANCH')}
-            className={`text-lg md:text-xl font-bold cursor-pointer hover:underline decoration-2 decoration-dotted underline-offset-4 flex items-center ${branchText}`}
+            aria-label="Change current branch"
+            title="Change current branch"
+            className={`text-lg md:text-xl font-bold cursor-pointer hover:underline decoration-2 decoration-dotted underline-offset-4 flex items-center ${branchText} bg-transparent border-none p-0 font-sans`}
           >
             <Icons.GitBranch className="w-5 h-5 mr-2 opacity-80" />
             <span className="truncate">{state.currentBranch}</span>
-          </div>
+          </button>
 
           {activeDropdown === 'BRANCH' && (
             <div className="absolute top-full left-0 z-50">
@@ -159,6 +164,8 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
         <div className="relative">
           <button
             onClick={(e) => handleDropdownClick(e, 'COMPARE')}
+            aria-label="Select comparison branch"
+            title="Select comparison branch"
             className={`bg-gray-200 hover:bg-gray-300 text-gray-700 px-2 py-0.5 rounded text-sm font-mono flex items-center transition-colors border border-transparent hover:border-gray-400 active:scale-95`}
           >
             {comparisonBranch}


### PR DESCRIPTION
I have implemented several micro-UX and accessibility improvements:
1. **FileList Line Counts**: Each file item now displays its additions and removals (e.g., `+10 -5`), similar to the "Dust Spore" view. This helps users quickly judge the size of changes without opening every file.
2. **RepoHeader Accessibility**:
   - Added `aria-label` and `title` to the repository and comparison branch selection buttons.
   - Upgraded the branch name display to a semantic `<button type="button">`, ensuring it is keyboard-focusable and correctly identified by screen readers.
3. **ProductTitleBar Accessibility**:
   - Added `aria-label` to the theme toggle button to describe its function (Switch to Prince/Princess Mode).

Verification:
- Ran `tsc` and `vite build` successfully.
- Used Playwright to take a screenshot of the mocked UI, confirming the new line counts and button behaviors.
- Updated `.Jules/palette.md` with learnings about information density in lists.

---
*PR created automatically by Jules for task [7414797009531305752](https://jules.google.com/task/7414797009531305752) started by @seanbud*