### PR TITLE
🛡️ Sentinel: Harden IPC handlers against malicious input

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Shell command injection via interpolated strings in `child_process.execSync` within IPC handlers.
 **Learning:** Passing unsanitized strings from the renderer to the main process for shell execution is extremely dangerous. Even quoting arguments is insufficient if the shell interprets special characters or if the input breaks out of quotes.
 **Prevention:** Always use argument arrays with `execFile` or `execFileSync` to bypass the shell entirely. Restrict IPC handlers to specific binaries (e.g., `git`) rather than allowing arbitrary commands.
+
+## 2026-02-24 - RCE via Unvalidated Settings and Windows `start`
+**Vulnerability:** Persistent Command Injection via `shell` and `externalEditor` settings, and an injection risk in `shell:open-terminal` on Windows.
+**Learning:** Even when using `execFile`, passing a user-controlled command to `cmd.exe /c start` is dangerous on Windows because `start` and `cmd` can still interpret metacharacters if not handled carefully. Furthermore, trusting IPC input to be the correct type (e.g., Array vs String) at the handler level is a common pitfall.
+**Prevention:** Validate all settings before persisting them using a whitelist of allowed characters. On Windows, when using `start`, always provide an explicit empty title `""` as the first argument to ensure subsequent arguments are correctly interpreted as the command. Perform runtime type validation on all IPC arguments.


### PR DESCRIPTION
This PR hardens several Electron IPC handlers in `electron/main.ts` to prevent command injection and other malicious input from reaching the main process.

Key changes:
1. **Settings Validation**: The `app:save-settings` handler now sanitizes the `shell` and `externalEditor` settings using a new `isValidSettingValue` helper that blocks shell metacharacters.
2. **Git Key Validation**: The `git:config-get` handler now validates keys against an alphanumeric/dot/hyphen whitelist via `isValidGitKey`.
3. **Runtime Type Checks**: The `git:cmd` handler now verifies that `args` is an array of strings at runtime, closing a potential type-based bypass.
4. **Windows `start` Hardening**: The `shell:open-terminal` handler on Windows now includes an explicit empty title `""` as the first argument to `start`, ensuring the shell command is correctly interpreted and reducing injection risks.

These changes follow the "Defense in Depth" principle and ensure that even if the renderer process were compromised, it would be much harder to achieve Remote Code Execution (RCE) on the host machine.

---
*PR created automatically by Jules for task [12163594787285628405](https://jules.google.com/task/12163594787285628405) started by @seanbud*