### PR TITLE
🎨 Palette: Improved accessibility and added 'Copy Branch Name' feature

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -21,3 +21,7 @@
 ## 2025-05-25 - [Accessibility for Toggle Buttons in Diff View]
 **Learning:** Using semantic `<button type="button">` with `aria-expanded` and `aria-label` for chunk headers and context expansion in diff views ensures that complex code-viewing interfaces are navigable for screen reader and keyboard users.
 **Action:** Always use buttons for toggles in the diff view and include `focus:ring-inset` to provide clear focus indicators without layout shifts.
+
+## 2025-05-26 - [Copy-to-Clipboard Accessibility]
+**Learning:** When adding "Copy to Clipboard" buttons, providing visual feedback (like an icon swap) is essential for UX. Additionally, ensuring these buttons have clear `aria-label` attributes and `title` tooltips helps both screen reader and mouse users.
+**Action:** Always implement a brief "success" state (e.g., 2s) when performing clipboard operations to confirm the action to the user.

--- a/App.tsx
+++ b/App.tsx
@@ -100,6 +100,11 @@ const App: React.FC = () => {
         e.preventDefault();
         searchInputRef.current?.focus();
       }
+      // 'Escape' to clear search and blur if focused
+      if (e.key === 'Escape' && document.activeElement === searchInputRef.current) {
+        setSearchQuery('');
+        searchInputRef.current?.blur();
+      }
     };
 
     window.addEventListener('keydown', handleKeyDown);

--- a/components/RepoHeader.tsx
+++ b/components/RepoHeader.tsx
@@ -36,6 +36,7 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
 }) => {
   const isPrincess = mode === ThemeMode.PRINCESS;
   const [activeDropdown, setActiveDropdown] = useState<DropdownType>(null);
+  const [copiedBranch, setCopiedBranch] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   // Theme Variables
@@ -137,13 +138,32 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
           onContextMenu={(e) => { e.stopPropagation(); onContextMenu(e, 'BRANCH'); }}
         >
           {/* Branch Name Dropdown Trigger */}
-          <div
+          <button
+            type="button"
             onClick={(e) => handleDropdownClick(e, 'BRANCH')}
-            className={`text-lg md:text-xl font-bold cursor-pointer hover:underline decoration-2 decoration-dotted underline-offset-4 flex items-center ${branchText}`}
+            aria-label={`Switch branch from ${state.currentBranch}`}
+            aria-haspopup="listbox"
+            aria-expanded={activeDropdown === 'BRANCH'}
+            className={`text-lg md:text-xl font-bold cursor-pointer hover:underline decoration-2 decoration-dotted underline-offset-4 flex items-center ${branchText} focus:outline-none focus:ring-2 focus:ring-offset-2 ${isPrincess ? 'focus:ring-pink-300' : 'focus:ring-blue-400'} rounded-sm`}
           >
             <Icons.GitBranch className="w-5 h-5 mr-2 opacity-80" />
             <span className="truncate">{state.currentBranch}</span>
-          </div>
+          </button>
+
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              navigator.clipboard.writeText(state.currentBranch);
+              setCopiedBranch(true);
+              setTimeout(() => setCopiedBranch(false), 2000);
+            }}
+            className={`ml-2 p-1 rounded-md transition-all ${isPrincess ? 'hover:bg-pink-200 text-pink-600' : 'hover:bg-blue-200 text-blue-600'} focus:outline-none focus:ring-2 ${isPrincess ? 'focus:ring-pink-300' : 'focus:ring-blue-400'}`}
+            aria-label="Copy branch name"
+            title="Copy branch name"
+          >
+            {copiedBranch ? <Icons.Check className="w-3.5 h-3.5" /> : <Icons.Copy className="w-3.5 h-3.5 opacity-60 hover:opacity-100" />}
+          </button>
 
           {activeDropdown === 'BRANCH' && (
             <div className="absolute top-full left-0 z-50">

--- a/constants.tsx
+++ b/constants.tsx
@@ -108,6 +108,12 @@ export const Icons = {
     <svg className={props.className} width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
       <polyline points="2 6 4.5 9 10 3"></polyline>
     </svg>
+  ),
+  Copy: ({ className }: { className?: string }) => (
+    <svg className={className} width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+    </svg>
   )
 };
 


### PR DESCRIPTION
This PR introduces several micro-UX improvements focused on accessibility and productivity:

1. **Copy Branch Name**: Users can now easily copy the current branch name to their clipboard by clicking a new icon next to the branch selector. The button provides immediate visual feedback by switching to a checkmark for 2 seconds.
2. **Accessible Branch Selector**: The branch selector was previously a non-semantic `div`. It has been converted to a `<button type="button">` with appropriate ARIA attributes (`aria-label`, `aria-haspopup`, `aria-expanded`), ensuring it is navigable via keyboard and screen readers.
3. **Search Input UX**: Added an `Escape` key handler to the search filter. When the search input is focused, pressing `Escape` will now clear the filter and blur the input, following standard web patterns.

These changes were verified using Playwright for visual consistency and `tsc` for type safety.

---
*PR created automatically by Jules for task [1016164881187495950](https://jules.google.com/task/1016164881187495950) started by @seanbud*