### PR TITLE
🎨 Palette: Improve dropdown accessibility and search input UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -21,3 +21,7 @@
 ## 2025-05-25 - [Accessibility for Toggle Buttons in Diff View]
 **Learning:** Using semantic `<button type="button">` with `aria-expanded` and `aria-label` for chunk headers and context expansion in diff views ensures that complex code-viewing interfaces are navigable for screen reader and keyboard users.
 **Action:** Always use buttons for toggles in the diff view and include `focus:ring-inset` to provide clear focus indicators without layout shifts.
+
+## 2025-05-26 - [Accessible Custom Dropdowns with Semantic Buttons]
+**Learning:** When implementing dropdown lists, use role="listbox" on the scrollable container and role="option" with aria-selected on the items (which should be semantic <button> elements) to provide proper structural context for screen readers.
+**Action:** Ensure custom dropdown components use semantic buttons for triggers and options, and manage ARIA states like `aria-expanded` and `aria-haspopup` correctly.

--- a/App.tsx
+++ b/App.tsx
@@ -223,12 +223,17 @@ const App: React.FC = () => {
                   aria-label="Filter files"
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
-                  className="w-full pl-2 pr-7 py-1.5 text-xs bg-white border border-gray-200 rounded text-gray-700 placeholder-gray-400 focus:outline-none focus:border-blue-400 focus:ring-2 focus:ring-blue-100 transition-all shadow-sm"
+                  className={`w-full pl-2 pr-7 py-1.5 text-xs bg-white border border-gray-200 rounded text-gray-700 placeholder-gray-400 focus:outline-none transition-all shadow-sm focus:ring-2 ${
+                    isPrincess
+                      ? 'focus:border-pink-400 focus:ring-pink-100'
+                      : 'focus:border-blue-400 focus:ring-blue-100'
+                  }`}
                 />
                 {searchQuery && (
                   <button
                     onClick={() => setSearchQuery('')}
                     aria-label="Clear filter"
+                    title="Clear filter"
                     className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 rounded-full p-0.5 hover:bg-gray-100 transition-colors"
                   >
                     <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">

--- a/components/RepoHeader.tsx
+++ b/components/RepoHeader.tsx
@@ -55,13 +55,16 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
-  const handleDropdownClick = (e: React.MouseEvent, type: DropdownType) => {
+  const handleDropdownClick = (e: React.MouseEvent | React.KeyboardEvent, type: DropdownType) => {
     e.stopPropagation();
     setActiveDropdown(activeDropdown === type ? null : type);
   };
 
   const renderDropdownList = (items: string[], onSelect: (item: string) => void, selectedItem: string, extraItems?: React.ReactNode) => (
-    <div className="absolute top-full mt-2 left-0 w-[280px] bg-white rounded-lg shadow-xl border border-gray-200 ring-1 ring-black/5 z-50 overflow-hidden flex flex-col animate-in fade-in slide-in-from-top-1 duration-100">
+    <div
+      role="listbox"
+      className="absolute top-full mt-2 left-0 w-[280px] bg-white rounded-lg shadow-xl border border-gray-200 ring-1 ring-black/5 z-50 overflow-hidden flex flex-col animate-in fade-in slide-in-from-top-1 duration-100"
+    >
       <div className="max-h-[300px] overflow-y-auto py-1">
         {items.map((item) => {
           const isSelected = item === selectedItem;
@@ -69,9 +72,12 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
             ? item.replace(/\\/g, '/').split('/').pop() || item
             : item;
           return (
-            <div
+            <button
               key={item}
-              className={`px-4 py-2.5 text-xs font-medium cursor-pointer flex items-center justify-between ${isSelected ? 'bg-gray-100 text-gray-900' : 'hover:bg-gray-50 text-gray-600'}`}
+              type="button"
+              role="option"
+              aria-selected={isSelected}
+              className={`w-full px-4 py-2.5 text-xs font-medium cursor-pointer flex items-center justify-between focus:outline-none focus:bg-gray-100 ${isSelected ? 'bg-gray-100 text-gray-900' : 'hover:bg-gray-50 text-gray-600'}`}
               onClick={(e) => {
                 e.stopPropagation();
                 onSelect(item);
@@ -80,13 +86,17 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
             >
               <span className="truncate">{displayName}</span>
               {isSelected && <Icons.Check />}
-            </div>
+            </button>
           );
         })}
         {extraItems}
       </div>
     </div>
   );
+
+  const focusRingClass = isPrincess
+    ? 'focus:outline-none focus:ring-2 focus:ring-pink-300'
+    : 'focus:outline-none focus:ring-2 focus:ring-blue-400';
 
   return (
     <div
@@ -101,7 +111,10 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
       >
         <button
           onClick={(e) => handleDropdownClick(e, 'REPO')}
-          className={`flex items-center space-x-2 px-3 py-1.5 rounded-full text-xs font-bold transition-all border shadow-sm active:scale-95 ${repoButtonBg}`}
+          aria-haspopup="listbox"
+          aria-expanded={activeDropdown === 'REPO'}
+          aria-label="Select repository"
+          className={`flex items-center space-x-2 px-3 py-1.5 rounded-full text-xs font-bold transition-all border shadow-sm active:scale-95 ${repoButtonBg} ${focusRingClass}`}
         >
           <Icons.GitCommit className="w-3.5 h-3.5 opacity-70" />
           <span className="max-w-[140px] truncate">{state.repoName}</span>
@@ -113,8 +126,9 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
           state.repoName,
           <>
             <div className="border-t border-gray-100 my-1" />
-            <div
-              className="px-4 py-2.5 text-xs font-medium cursor-pointer hover:bg-gray-50 text-blue-600 flex items-center gap-2"
+            <button
+              type="button"
+              className={`w-full px-4 py-2.5 text-xs font-medium cursor-pointer hover:bg-gray-50 text-blue-600 flex items-center gap-2 focus:outline-none focus:bg-gray-50 ${focusRingClass}`}
               onClick={(e) => {
                 e.stopPropagation();
                 onOpenRepo?.();
@@ -125,7 +139,7 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
                 <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
               </svg>
               Open Local Repository...
-            </div>
+            </button>
           </>
         )}
       </div>
@@ -137,13 +151,17 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
           onContextMenu={(e) => { e.stopPropagation(); onContextMenu(e, 'BRANCH'); }}
         >
           {/* Branch Name Dropdown Trigger */}
-          <div
+          <button
+            type="button"
             onClick={(e) => handleDropdownClick(e, 'BRANCH')}
-            className={`text-lg md:text-xl font-bold cursor-pointer hover:underline decoration-2 decoration-dotted underline-offset-4 flex items-center ${branchText}`}
+            aria-haspopup="listbox"
+            aria-expanded={activeDropdown === 'BRANCH'}
+            aria-label="Select branch"
+            className={`text-lg md:text-xl font-bold cursor-pointer hover:underline decoration-2 decoration-dotted underline-offset-4 flex items-center ${branchText} rounded px-1 -ml-1 ${focusRingClass}`}
           >
             <Icons.GitBranch className="w-5 h-5 mr-2 opacity-80" />
             <span className="truncate">{state.currentBranch}</span>
-          </div>
+          </button>
 
           {activeDropdown === 'BRANCH' && (
             <div className="absolute top-full left-0 z-50">
@@ -158,8 +176,12 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
         {/* Comparison Branch Dropdown */}
         <div className="relative">
           <button
+            type="button"
             onClick={(e) => handleDropdownClick(e, 'COMPARE')}
-            className={`bg-gray-200 hover:bg-gray-300 text-gray-700 px-2 py-0.5 rounded text-sm font-mono flex items-center transition-colors border border-transparent hover:border-gray-400 active:scale-95`}
+            aria-haspopup="listbox"
+            aria-expanded={activeDropdown === 'COMPARE'}
+            aria-label="Select comparison branch"
+            className={`bg-gray-200 hover:bg-gray-300 text-gray-700 px-2 py-0.5 rounded text-sm font-mono flex items-center transition-colors border border-transparent hover:border-gray-400 active:scale-95 ${focusRingClass}`}
           >
             {comparisonBranch}
             <span className="ml-1 opacity-50 text-[10px]">▼</span>


### PR DESCRIPTION
This PR introduces several micro-UX and accessibility improvements to the Git Cleanup PRincess interface:

1. **Accessible Dropdowns:** Converted the repository, branch, and comparison dropdowns in `RepoHeader.tsx` from non-semantic `div` elements to semantic `button` elements. This enables full keyboard navigation support.
2. **ARIA Enhancement:** Added appropriate ARIA roles and attributes (`listbox`, `option`, `aria-expanded`, etc.) to ensure screen readers can correctly interpret the dropdown state and structure.
3. **Visual Polish:** Implemented theme-aware focus rings across high-interaction areas. Focus indicators now use `pink-300` in Princess mode and `blue-400` in Prince mode, ensuring clear visual feedback for keyboard users.
4. **Search Discoverability:** Added a `title` attribute to the "Clear filter" button to provide a native tooltip, helping users understand the button's function.
5. **Standardized Focus States:** Refined the search input's focus styling in `App.tsx` to match the application's theme-switching logic.

Verified via `pnpm exec tsc --noEmit` and manual frontend verification using Playwright screenshots.

---
*PR created automatically by Jules for task [17032836347744248244](https://jules.google.com/task/17032836347744248244) started by @seanbud*