### PR TITLE
⚡ Bolt: parallelize Git and IPC operations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2026-02-22 - [Memoizing Derived Props for Heavy Components]
 **Learning:** Passing object literals as props (e.g., `file={ { ...file, diffContent } }`) to heavy components like `DiffView` causes them to re-render and re-parse data on every parent render, even if the data hasn't changed. Memoizing these derived objects with `useMemo` is critical for maintaining reference stability and skipping expensive processing.
 **Action:** Always wrap derived objects in `useMemo` if they are passed to components that perform heavy parsing or rendering (like diff viewers or graphs). Use specific identity dependencies (like IDs) to balance performance and correctness.
+
+## 2025-05-16 - [Parallelizing Git and IPC Operations]
+**Learning:** Sequential await calls for independent Git or IPC operations (like config fetching or multi-file actions) lead to significant user-perceived latency. Parallelizing these with `Promise.all` and batching multiple file paths into single CLI commands (e.g., `git rm`) drastically reduces total execution time and process overhead.
+**Action:** Always identify independent asynchronous operations and parallelize them. When performing actions on multiple files, prioritize bulk CLI commands over sequential loops to minimize process spawns and refreshes.

--- a/hooks/useGitState.ts
+++ b/hooks/useGitState.ts
@@ -63,25 +63,26 @@ export function useGitState(): UseGitStateReturn {
 
     const refreshGitState = useCallback(async () => {
         try {
-            const [repoName, currentBranch, upstreamBranch, config, branchList, commits, settings, bestComp] = await Promise.all([
+            // Fetch base information in parallel
+            const [repoName, currentBranch, upstreamBranch, config, branchList, commits, settings] = await Promise.all([
                 GitService.getRepoName(),
                 GitService.getCurrentBranch(),
                 GitService.getUpstreamBranch(),
                 GitService.getGitConfig(),
                 GitService.getBranches(),
                 GitService.getCommitGraph(),
-                GitService.getAppSettings(),
-                GitService.getBestComparisonBranch()
+                GitService.getAppSettings()
             ]);
 
-            // If we don't have a comparison branch set yet, use the best guess
+            // Use already fetched data to find best comparison branch if not set
             let activeComp = comparisonBranch;
             if (!activeComp) {
-                activeComp = bestComp;
-                setComparisonBranch(bestComp);
+                activeComp = await GitService.getBestComparisonBranch(currentBranch, upstreamBranch, branchList);
+                setComparisonBranch(activeComp);
             }
 
-            const files = await GitService.getStatusFiles(activeComp);
+            // Fetch files using already fetched current branch name to avoid redundant CLI calls
+            const files = await GitService.getStatusFiles(activeComp, currentBranch);
 
             setGitState(prev => ({
                 ...prev,
@@ -205,14 +206,14 @@ export function useGitState(): UseGitStateReturn {
         setCharacterState(actionType === 'RESTORE' ? CharacterState.ACTION_GOOD : CharacterState.ACTION_BAD);
 
         const selectedFiles = gitState.files.filter(f => gitState.selectedFileIds.has(f.id));
+        const filePaths = selectedFiles.map(f => f.path);
 
         try {
-            for (const file of selectedFiles) {
-                if (actionType === 'RESTORE') {
-                    await GitService.restoreFile(file.path);
-                } else {
-                    await GitService.removeFile(file.path);
-                }
+            // Bulk operation based on action type
+            if (actionType === 'RESTORE') {
+                await GitService.discardChanges(filePaths);
+            } else {
+                await GitService.removeFiles(filePaths);
             }
 
             await refreshGitState();

--- a/services/gitService.ts
+++ b/services/gitService.ts
@@ -57,19 +57,23 @@ export class GitService {
         return res.success ? res.stdout.trim() : '';
     }
 
-    static async getBestComparisonBranch(): Promise<string> {
+    static async getBestComparisonBranch(
+        currentBranch?: string,
+        upstreamBranch?: string,
+        branchList?: string[]
+    ): Promise<string> {
         // 1. Try upstream
-        const upstream = await this.getUpstreamBranch();
+        const upstream = upstreamBranch !== undefined ? upstreamBranch : await this.getUpstreamBranch();
         if (upstream) return upstream;
 
         // 2. Try common branches
         const common = ['develop', 'development', 'main', 'master'];
-        const branches = await this.getBranches();
+        const branches = branchList || await this.getBranches();
+        const current = currentBranch || await this.getCurrentBranch();
 
         for (const target of common) {
             if (branches.includes(target)) {
                 // Verify it's not the same branch
-                const current = await this.getCurrentBranch();
                 if (current !== target) return target;
             }
         }
@@ -81,14 +85,13 @@ export class GitService {
             for (const target of common) {
                 const rTarget = `origin/${target}`;
                 if (remoteBranches.some((rb: string) => rb.includes(rTarget))) {
-                    const current = await this.getCurrentBranch();
                     if (current !== rTarget) return rTarget;
                 }
             }
         }
 
         // 4. Fallback to self
-        return await this.getCurrentBranch();
+        return current;
     }
 
     static async getBranches(): Promise<string[]> {
@@ -100,7 +103,7 @@ export class GitService {
             .map((b: string) => b.replace('*', '').trim());
     }
 
-    static async getStatusFiles(comparisonBranch?: string): Promise<GitFile[]> {
+    static async getStatusFiles(comparisonBranch?: string, currentBranchName?: string): Promise<GitFile[]> {
         const files: GitFile[] = [];
         const seenPaths = new Set<string>();
 
@@ -133,7 +136,7 @@ export class GitService {
         }
 
         // 2. Get committed differences if comparing to another branch
-        const currentBranch = await this.getCurrentBranch();
+        const currentBranch = currentBranchName || await this.getCurrentBranch();
         if (comparisonBranch && comparisonBranch !== currentBranch) {
             const diffRes = await git('diff', '--name-status', `${comparisonBranch}...HEAD`);
             if (diffRes.success && diffRes.stdout.trim()) {
@@ -182,18 +185,21 @@ export class GitService {
             }
         };
 
-        // 1. Get uncommitted stats (staged + unstaged)
-        // Use separate commands for staged and unstaged to avoid issues with empty repos (no HEAD)
-        const localStats = await git('diff', '--numstat', '--text');
-        if (localStats.success) addStats(localStats.stdout);
-        const stagedStats = await git('diff', '--numstat', '--text', '--cached');
-        if (stagedStats.success) addStats(stagedStats.stdout);
+        // Fetch line stats in parallel
+        const statsPromises = [
+            git('diff', '--numstat', '--text'), // 1a. Uncommitted (unstaged)
+            git('diff', '--numstat', '--text', '--cached') // 1b. Uncommitted (staged)
+        ];
 
         // 2. Get committed stats for the branch comparison
         if (comparisonBranch && comparisonBranch !== currentBranch) {
-            const branchStats = await git('diff', '--numstat', '--text', `${comparisonBranch}...HEAD`);
-            if (branchStats.success) addStats(branchStats.stdout);
+            statsPromises.push(git('diff', '--numstat', '--text', `${comparisonBranch}...HEAD`));
         }
+
+        const statsResults = await Promise.all(statsPromises);
+        statsResults.forEach(res => {
+            if (res.success) addStats(res.stdout);
+        });
 
         // Apply stats to files
         for (const file of files) {
@@ -238,14 +244,20 @@ export class GitService {
     }
 
     static async getGitConfig(): Promise<GitConfig> {
-        // @ts-ignore
-        const name = await window.electronAPI.gitConfigGet('user.name');
-        // @ts-ignore
-        const email = await window.electronAPI.gitConfigGet('user.email');
-        // @ts-ignore
-        const defaultBranch = await window.electronAPI.gitConfigGet('init.defaultBranch') || 'main';
+        const [name, email, defaultBranch] = await Promise.all([
+            // @ts-ignore
+            window.electronAPI.gitConfigGet('user.name'),
+            // @ts-ignore
+            window.electronAPI.gitConfigGet('user.email'),
+            // @ts-ignore
+            window.electronAPI.gitConfigGet('init.defaultBranch')
+        ]);
 
-        return { name, email, defaultBranch };
+        return {
+            name: name || '',
+            email: email || '',
+            defaultBranch: defaultBranch || 'main'
+        };
     }
 
     static async setGitConfig(key: string, value: string): Promise<boolean> {
@@ -286,14 +298,26 @@ export class GitService {
     }
 
     static async removeFile(filePath: string): Promise<boolean> {
+        return this.removeFiles([filePath]);
+    }
+
+    static async removeFiles(filePaths: string[]): Promise<boolean> {
+        if (filePaths.length === 0) return true;
+
         // 1. Remove from git index first (keep on disk)
         // Use --ignore-unmatch so it doesn't fail if the file is untracked
-        await git('rm', '--cached', '-f', '--ignore-unmatch', filePath);
+        await git('rm', '--cached', '-f', '--ignore-unmatch', ...filePaths);
 
-        // 2. Move the local file to trash/recycle bin
-        // @ts-ignore
-        const res = await window.electronAPI.trashFile(filePath);
-        return res.success;
+        // 2. Move the local files to trash/recycle bin in parallel
+        try {
+            const trashResults = await Promise.all(
+                filePaths.map(path => (window.electronAPI as any).trashFile(path))
+            );
+            return trashResults.every(res => res.success);
+        } catch (err) {
+            console.error('Failed to trash files:', err);
+            return false;
+        }
     }
 
     static async getCommitGraph(): Promise<CommitNode[]> {


### PR DESCRIPTION
I have implemented several performance optimizations to the Git state refresh cycle and file action handlers. By parallelizing independent Git CLI and Electron IPC calls using `Promise.all`, and by batching file actions into single bulk commands, I have significantly reduced the application's responsiveness during frequent updates and user actions. Redundant Git process spawns have also been eliminated by caching and passing known Git state through the service layer.

---
*PR created automatically by Jules for task [11106155184063261499](https://jules.google.com/task/11106155184063261499) started by @seanbud*