### PR TITLE
🎨 Palette: Accessibility and UX improvements for RepoHeader and search filter

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,7 @@
+## 2025-05-26 - [Accessible and Semantic Dropdown Menus]
+**Learning:** Converting `div`-based dropdown triggers and list items to semantic `<button>` elements with appropriate ARIA roles (`listbox`, `option`) and attributes (`aria-haspopup`, `aria-expanded`, `aria-selected`) significantly improves keyboard navigation and screen reader support without requiring layout changes.
+**Action:** Audit and convert all interactive "triggers" from `div` to `<button type="button">` and apply the `listbox`/`option` pattern for selection-based menus.
+
+## 2025-05-26 - [Dual Visual and Screen Reader Feedback for Icon Buttons]
+**Learning:** Sighted users benefit from native tooltips (`title` attribute) on icon-only buttons, which complements the `aria-label` used by screen readers, providing a consistent experience across different user groups.
+**Action:** Always include both `aria-label` and `title` attributes on icon-only buttons to ensure they are descriptive and discoverable.

--- a/App.tsx
+++ b/App.tsx
@@ -229,6 +229,7 @@ const App: React.FC = () => {
                   <button
                     onClick={() => setSearchQuery('')}
                     aria-label="Clear filter"
+                    title="Clear filter"
                     className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 rounded-full p-0.5 hover:bg-gray-100 transition-colors"
                   >
                     <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">

--- a/components/RepoHeader.tsx
+++ b/components/RepoHeader.tsx
@@ -62,16 +62,19 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
 
   const renderDropdownList = (items: string[], onSelect: (item: string) => void, selectedItem: string, extraItems?: React.ReactNode) => (
     <div className="absolute top-full mt-2 left-0 w-[280px] bg-white rounded-lg shadow-xl border border-gray-200 ring-1 ring-black/5 z-50 overflow-hidden flex flex-col animate-in fade-in slide-in-from-top-1 duration-100">
-      <div className="max-h-[300px] overflow-y-auto py-1">
+      <div className="max-h-[300px] overflow-y-auto py-1" role="listbox">
         {items.map((item) => {
           const isSelected = item === selectedItem;
           const displayName = item.includes('/') || item.includes('\\')
             ? item.replace(/\\/g, '/').split('/').pop() || item
             : item;
           return (
-            <div
+            <button
               key={item}
-              className={`px-4 py-2.5 text-xs font-medium cursor-pointer flex items-center justify-between ${isSelected ? 'bg-gray-100 text-gray-900' : 'hover:bg-gray-50 text-gray-600'}`}
+              type="button"
+              role="option"
+              aria-selected={isSelected}
+              className={`w-full px-4 py-2.5 text-xs font-medium cursor-pointer flex items-center justify-between transition-colors focus:outline-none focus:bg-gray-100 ${isSelected ? 'bg-gray-100 text-gray-900' : 'hover:bg-gray-50 text-gray-600'}`}
               onClick={(e) => {
                 e.stopPropagation();
                 onSelect(item);
@@ -80,7 +83,7 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
             >
               <span className="truncate">{displayName}</span>
               {isSelected && <Icons.Check />}
-            </div>
+            </button>
           );
         })}
         {extraItems}
@@ -100,8 +103,12 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
         onContextMenu={(e) => { e.stopPropagation(); onContextMenu(e, 'REPO'); }}
       >
         <button
+          type="button"
           onClick={(e) => handleDropdownClick(e, 'REPO')}
-          className={`flex items-center space-x-2 px-3 py-1.5 rounded-full text-xs font-bold transition-all border shadow-sm active:scale-95 ${repoButtonBg}`}
+          aria-haspopup="listbox"
+          aria-expanded={activeDropdown === 'REPO'}
+          aria-label="Select repository"
+          className={`flex items-center space-x-2 px-3 py-1.5 rounded-full text-xs font-bold transition-all border shadow-sm active:scale-95 ${repoButtonBg} focus:outline-none focus:ring-2 ${isPrincess ? 'focus:ring-pink-300' : 'focus:ring-blue-400'}`}
         >
           <Icons.GitCommit className="w-3.5 h-3.5 opacity-70" />
           <span className="max-w-[140px] truncate">{state.repoName}</span>
@@ -113,8 +120,9 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
           state.repoName,
           <>
             <div className="border-t border-gray-100 my-1" />
-            <div
-              className="px-4 py-2.5 text-xs font-medium cursor-pointer hover:bg-gray-50 text-blue-600 flex items-center gap-2"
+            <button
+              type="button"
+              className="w-full px-4 py-2.5 text-xs font-medium cursor-pointer hover:bg-gray-50 text-blue-600 flex items-center gap-2 focus:outline-none focus:bg-gray-50"
               onClick={(e) => {
                 e.stopPropagation();
                 onOpenRepo?.();
@@ -125,7 +133,7 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
                 <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
               </svg>
               Open Local Repository...
-            </div>
+            </button>
           </>
         )}
       </div>
@@ -137,13 +145,17 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
           onContextMenu={(e) => { e.stopPropagation(); onContextMenu(e, 'BRANCH'); }}
         >
           {/* Branch Name Dropdown Trigger */}
-          <div
+          <button
+            type="button"
             onClick={(e) => handleDropdownClick(e, 'BRANCH')}
-            className={`text-lg md:text-xl font-bold cursor-pointer hover:underline decoration-2 decoration-dotted underline-offset-4 flex items-center ${branchText}`}
+            aria-haspopup="listbox"
+            aria-expanded={activeDropdown === 'BRANCH'}
+            aria-label="Select branch"
+            className={`text-lg md:text-xl font-bold cursor-pointer hover:underline decoration-2 decoration-dotted underline-offset-4 flex items-center ${branchText} focus:outline-none focus:ring-2 ${isPrincess ? 'focus:ring-pink-300' : 'focus:ring-blue-400'} rounded px-1 -ml-1`}
           >
             <Icons.GitBranch className="w-5 h-5 mr-2 opacity-80" />
             <span className="truncate">{state.currentBranch}</span>
-          </div>
+          </button>
 
           {activeDropdown === 'BRANCH' && (
             <div className="absolute top-full left-0 z-50">
@@ -158,8 +170,12 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
         {/* Comparison Branch Dropdown */}
         <div className="relative">
           <button
+            type="button"
             onClick={(e) => handleDropdownClick(e, 'COMPARE')}
-            className={`bg-gray-200 hover:bg-gray-300 text-gray-700 px-2 py-0.5 rounded text-sm font-mono flex items-center transition-colors border border-transparent hover:border-gray-400 active:scale-95`}
+            aria-haspopup="listbox"
+            aria-expanded={activeDropdown === 'COMPARE'}
+            aria-label="Select comparison branch"
+            className={`bg-gray-200 hover:bg-gray-300 text-gray-700 px-2 py-0.5 rounded text-sm font-mono flex items-center transition-colors border border-transparent hover:border-gray-400 active:scale-95 focus:outline-none focus:ring-2 ${isPrincess ? 'focus:ring-pink-300' : 'focus:ring-blue-400'}`}
           >
             {comparisonBranch}
             <span className="ml-1 opacity-50 text-[10px]">▼</span>


### PR DESCRIPTION
### 💡 What: The UX enhancement added
This PR improves the accessibility and semantic structure of the `RepoHeader` component and adds a native tooltip to the search filter's "Clear filter" button.

### 🎯 Why: The user problem it solves
The repository, branch, and comparison dropdowns in the `RepoHeader` were using `div` elements for triggers and list items, making them inaccessible to keyboard users and screen readers. Additionally, the icon-only "Clear filter" button lacked a visual tooltip, making its function less discoverable for sighted users.

### ♿ Accessibility: Any a11y improvements made
- **Semantic Elements:** Converted `div` elements to `<button type="button">` for all dropdown triggers and list items to ensure native focus and interaction.
- **ARIA Roles & Attributes:** Implemented the `listbox` and `option` pattern. Added `aria-haspopup`, `aria-expanded`, `aria-label`, and `aria-selected` to provide proper structural context for screen readers.
- **Focus Indicators:** Added theme-aware focus rings (`focus:ring-pink-300` for Princess mode, `focus:ring-blue-400` for Prince mode) to improve visibility for keyboard navigation.

### 📸 Before/After: Screenshots
- Verification screenshot for `RepoHeader`: [repo_header.png]
- Verification screenshot for search filter: [search_filter.png]

---
*PR created automatically by Jules for task [2948666318234817698](https://jules.google.com/task/2948666318234817698) started by @seanbud*