### PR TITLE
🎨 Palette: Improve accessibility of RepoHeader dropdowns

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -21,3 +21,7 @@
 ## 2025-05-25 - [Accessibility for Toggle Buttons in Diff View]
 **Learning:** Using semantic `<button type="button">` with `aria-expanded` and `aria-label` for chunk headers and context expansion in diff views ensures that complex code-viewing interfaces are navigable for screen reader and keyboard users.
 **Action:** Always use buttons for toggles in the diff view and include `focus:ring-inset` to provide clear focus indicators without layout shifts.
+
+## 2025-05-26 - [Semantic Buttons for Header Dropdowns]
+**Learning:** Converting dropdown triggers in headers from `div` elements to semantic `<button type="button">` elements with appropriate ARIA attributes (`aria-haspopup`, `aria-expanded`) significantly improves keyboard accessibility and structural clarity.
+**Action:** Ensure all dropdown triggers are semantic buttons and provide theme-appropriate focus rings for clear visual feedback.

--- a/components/RepoHeader.tsx
+++ b/components/RepoHeader.tsx
@@ -61,7 +61,10 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
   };
 
   const renderDropdownList = (items: string[], onSelect: (item: string) => void, selectedItem: string, extraItems?: React.ReactNode) => (
-    <div className="absolute top-full mt-2 left-0 w-[280px] bg-white rounded-lg shadow-xl border border-gray-200 ring-1 ring-black/5 z-50 overflow-hidden flex flex-col animate-in fade-in slide-in-from-top-1 duration-100">
+    <div
+      role="listbox"
+      className="absolute top-full mt-2 left-0 w-[280px] bg-white rounded-lg shadow-xl border border-gray-200 ring-1 ring-black/5 z-50 overflow-hidden flex flex-col animate-in fade-in slide-in-from-top-1 duration-100"
+    >
       <div className="max-h-[300px] overflow-y-auto py-1">
         {items.map((item) => {
           const isSelected = item === selectedItem;
@@ -69,9 +72,12 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
             ? item.replace(/\\/g, '/').split('/').pop() || item
             : item;
           return (
-            <div
+            <button
               key={item}
-              className={`px-4 py-2.5 text-xs font-medium cursor-pointer flex items-center justify-between ${isSelected ? 'bg-gray-100 text-gray-900' : 'hover:bg-gray-50 text-gray-600'}`}
+              type="button"
+              role="option"
+              aria-selected={isSelected}
+              className={`w-full text-left px-4 py-2.5 text-xs font-medium cursor-pointer flex items-center justify-between ${isSelected ? 'bg-gray-100 text-gray-900' : 'hover:bg-gray-50 text-gray-600'} focus:outline-none focus:bg-gray-50 transition-colors`}
               onClick={(e) => {
                 e.stopPropagation();
                 onSelect(item);
@@ -80,7 +86,7 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
             >
               <span className="truncate">{displayName}</span>
               {isSelected && <Icons.Check />}
-            </div>
+            </button>
           );
         })}
         {extraItems}
@@ -100,8 +106,12 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
         onContextMenu={(e) => { e.stopPropagation(); onContextMenu(e, 'REPO'); }}
       >
         <button
+          type="button"
           onClick={(e) => handleDropdownClick(e, 'REPO')}
-          className={`flex items-center space-x-2 px-3 py-1.5 rounded-full text-xs font-bold transition-all border shadow-sm active:scale-95 ${repoButtonBg}`}
+          aria-haspopup="listbox"
+          aria-expanded={activeDropdown === 'REPO'}
+          aria-label="Change repository"
+          className={`flex items-center space-x-2 px-3 py-1.5 rounded-full text-xs font-bold transition-all border shadow-sm active:scale-95 ${repoButtonBg} focus:outline-none focus:ring-2 focus:ring-offset-2 ${isPrincess ? 'focus:ring-pink-300' : 'focus:ring-blue-400'}`}
         >
           <Icons.GitCommit className="w-3.5 h-3.5 opacity-70" />
           <span className="max-w-[140px] truncate">{state.repoName}</span>
@@ -113,8 +123,9 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
           state.repoName,
           <>
             <div className="border-t border-gray-100 my-1" />
-            <div
-              className="px-4 py-2.5 text-xs font-medium cursor-pointer hover:bg-gray-50 text-blue-600 flex items-center gap-2"
+            <button
+              type="button"
+              className="w-full text-left px-4 py-2.5 text-xs font-medium cursor-pointer hover:bg-gray-50 text-blue-600 flex items-center gap-2 focus:outline-none focus:bg-gray-50 transition-colors"
               onClick={(e) => {
                 e.stopPropagation();
                 onOpenRepo?.();
@@ -125,7 +136,7 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
                 <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
               </svg>
               Open Local Repository...
-            </div>
+            </button>
           </>
         )}
       </div>
@@ -137,13 +148,17 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
           onContextMenu={(e) => { e.stopPropagation(); onContextMenu(e, 'BRANCH'); }}
         >
           {/* Branch Name Dropdown Trigger */}
-          <div
+          <button
+            type="button"
             onClick={(e) => handleDropdownClick(e, 'BRANCH')}
-            className={`text-lg md:text-xl font-bold cursor-pointer hover:underline decoration-2 decoration-dotted underline-offset-4 flex items-center ${branchText}`}
+            aria-haspopup="listbox"
+            aria-expanded={activeDropdown === 'BRANCH'}
+            aria-label="Switch branch"
+            className={`text-lg md:text-xl font-bold cursor-pointer hover:underline decoration-2 decoration-dotted underline-offset-4 flex items-center ${branchText} focus:outline-none focus:ring-2 focus:ring-offset-2 rounded px-1 -ml-1 ${isPrincess ? 'focus:ring-pink-300' : 'focus:ring-blue-400'}`}
           >
             <Icons.GitBranch className="w-5 h-5 mr-2 opacity-80" />
             <span className="truncate">{state.currentBranch}</span>
-          </div>
+          </button>
 
           {activeDropdown === 'BRANCH' && (
             <div className="absolute top-full left-0 z-50">
@@ -158,8 +173,12 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
         {/* Comparison Branch Dropdown */}
         <div className="relative">
           <button
+            type="button"
             onClick={(e) => handleDropdownClick(e, 'COMPARE')}
-            className={`bg-gray-200 hover:bg-gray-300 text-gray-700 px-2 py-0.5 rounded text-sm font-mono flex items-center transition-colors border border-transparent hover:border-gray-400 active:scale-95`}
+            aria-haspopup="listbox"
+            aria-expanded={activeDropdown === 'COMPARE'}
+            aria-label="Change comparison branch"
+            className={`bg-gray-200 hover:bg-gray-300 text-gray-700 px-2 py-0.5 rounded text-sm font-mono flex items-center transition-colors border border-transparent hover:border-gray-400 active:scale-95 focus:outline-none focus:ring-2 focus:ring-offset-2 ${isPrincess ? 'focus:ring-pink-300' : 'focus:ring-blue-400'}`}
           >
             {comparisonBranch}
             <span className="ml-1 opacity-50 text-[10px]">▼</span>


### PR DESCRIPTION
This PR improves the accessibility and keyboard navigability of the `RepoHeader` component.

### 💡 What
- Replaced non-semantic `div` elements used as dropdown triggers with proper `<button type="button">` elements.
- Added comprehensive ARIA attributes: `aria-haspopup="listbox"`, `aria-expanded`, and descriptive `aria-label`s.
- Updated the `renderDropdownList` helper to use `role="listbox"` for the container and `role="option"` with `aria-selected` for items.
- Converted dropdown items from `div` to `<button type="button">` for native keyboard support.
- Added theme-aware focus rings (`focus:ring-pink-300` for Princess, `focus:ring-blue-400` for Prince).

### 🎯 Why
The previous implementation used `div` elements for dropdown triggers and items, which are not natively focusable or accessible to screen readers. This made it difficult for users relying on keyboard navigation or assistive technologies to switch repositories or branches.

### ♿ Accessibility
- All interactive elements in the header are now semantic buttons.
- Screen readers now receive correct context about the dropdown state and content.
- Clear visual focus indicators are provided for all interactive states.

---
*PR created automatically by Jules for task [7935650425456743368](https://jules.google.com/task/7935650425456743368) started by @seanbud*