### PR TITLE
🛡️ Sentinel: [HIGH] Harden IPC handlers with path and input validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Shell command injection via interpolated strings in `child_process.execSync` within IPC handlers.
 **Learning:** Passing unsanitized strings from the renderer to the main process for shell execution is extremely dangerous. Even quoting arguments is insufficient if the shell interprets special characters or if the input breaks out of quotes.
 **Prevention:** Always use argument arrays with `execFile` or `execFileSync` to bypass the shell entirely. Restrict IPC handlers to specific binaries (e.g., `git`) rather than allowing arbitrary commands.
+
+## 2026-03-05 - Missing Validation in Shell and File IPC Handlers
+**Vulnerability:** IPC handlers for shell operations (trash, open) and file reading lacked validation, allowing path traversal or execution of potentially dangerous user-configured strings.
+**Learning:** Even when using "safe" APIs like `shell.trashItem` or `execFile`, lack of input validation can still lead to unauthorized file access or shell injection if the inputs (like file paths or editor commands) are sourced from the renderer without server-side verification.
+**Prevention:** Implement a centralized security utility to validate paths against the active repository (`isSafePath`) and sanitize user-configurable settings (`isValidSettingValue`). Always validate inputs in the main process before passing them to OS-level APIs.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { execSync, execFileSync, execFile } from 'child_process';
 import fs from 'fs';
 import { autoUpdater } from 'electron-updater';
+import { isSafePath, isValidGitKey, isValidSettingValue } from './security.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -94,6 +95,7 @@ function getSettings() {
 function saveSettings(settings: any) {
     fs.writeFileSync(SETTINGS_PATH, JSON.stringify(settings, null, 2));
 }
+
 
 function createWindow() {
     process.env.DIST_ELECTRON = path.join(__dirname, '../dist-electron');
@@ -318,6 +320,9 @@ app.whenReady().then(() => {
     });
 
     ipcMain.handle('git:config-get', async (_, key) => {
+        if (!isValidGitKey(key)) {
+            return '';
+        }
         try {
             return execFileSync('git', ['config', '--get', key], {
                 encoding: 'utf-8',
@@ -387,6 +392,9 @@ app.whenReady().then(() => {
     });
 
     ipcMain.handle('shell:open-editor', async (_, filePath: string) => {
+        if (!isSafePath(filePath, currentCwd)) {
+            return { success: false, error: 'Access denied' };
+        }
         const settings = getSettings();
         const editor = settings.externalEditor || 'code';
         try {
@@ -414,15 +422,22 @@ app.whenReady().then(() => {
     });
 
     ipcMain.handle('shell:open-path', (_, filePath: string) => {
-        shell.showItemInFolder(filePath);
+        if (isSafePath(filePath, currentCwd)) {
+            shell.showItemInFolder(path.resolve(currentCwd, filePath));
+        }
     });
 
     ipcMain.handle('shell:open-directory', (_, dirPath: string) => {
-        shell.openPath(dirPath);
+        if (isSafePath(dirPath, currentCwd)) {
+            shell.openPath(path.resolve(currentCwd, dirPath));
+        }
     });
 
     ipcMain.handle('shell:trash-item', async (_, filePath: string) => {
-        const fullPath = path.isAbsolute(filePath) ? filePath : path.join(currentCwd, filePath);
+        if (!isSafePath(filePath, currentCwd)) {
+            return { success: false, error: 'Access denied' };
+        }
+        const fullPath = path.resolve(currentCwd, filePath);
         try {
             await shell.trashItem(fullPath);
             return { success: true };
@@ -434,12 +449,10 @@ app.whenReady().then(() => {
     // File Preview: read file from disk as base64 data URI
     ipcMain.handle('file:read-base64', (_, relativePath: string) => {
         try {
-            const fullPath = path.resolve(currentCwd, relativePath);
-            // Security: Prevent path traversal by ensuring the file is within the repository
-            const relative = path.relative(currentCwd, fullPath);
-            if (relative.startsWith('..') || path.isAbsolute(relative)) {
+            if (!isSafePath(relativePath, currentCwd)) {
                 return { success: false, error: 'Access denied: Path outside of repository' };
             }
+            const fullPath = path.resolve(currentCwd, relativePath);
             if (!fs.existsSync(fullPath)) return { success: false, error: 'File not found' };
             const buffer = fs.readFileSync(fullPath);
             const ext = path.extname(fullPath).toLowerCase();
@@ -513,6 +526,13 @@ app.whenReady().then(() => {
     });
 
     ipcMain.handle('app:save-settings', (_, settings) => {
+        if (settings.externalEditor && !isValidSettingValue(settings.externalEditor)) {
+            return { success: false, error: 'Invalid editor' };
+        }
+        if (settings.shell && !isValidSettingValue(settings.shell)) {
+            return { success: false, error: 'Invalid shell' };
+        }
         saveSettings(settings);
+        return { success: true };
     });
 });

--- a/electron/security.ts
+++ b/electron/security.ts
@@ -1,0 +1,28 @@
+import path from 'node:path';
+
+/**
+ * Security: Validates that a path is within the base directory
+ * to prevent path traversal attacks.
+ */
+export function isSafePath(filePath: string, baseDir: string): boolean {
+    const resolvedPath = path.resolve(baseDir, filePath);
+    const relative = path.relative(baseDir, resolvedPath);
+    return !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+/**
+ * Security: Validates git config keys to prevent command injection
+ * or unexpected behavior.
+ */
+export function isValidGitKey(key: string): boolean {
+    return /^[a-zA-Z0-9.-]+$/.test(key);
+}
+
+/**
+ * Security: Validates settings values to prevent shell injection.
+ */
+export function isValidSettingValue(value: string): boolean {
+    if (typeof value !== 'string' || value.length > 255) return false;
+    // Disallow common shell metacharacters
+    return !/[&|;<>$`]/.test(value);
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev": "vite",
     "web:dev": "vite --config vite.web.config.ts",
+    "test": "bun test tests/*.test.ts",
     "build": "tsc && vite build && electron-builder",
     "preview": "vite preview",
     "clean": "node -e \"const fs=require('fs');['dist','dist-electron','release'].forEach(d=>{if(fs.existsSync(d)){fs.rmSync(d,{recursive:true,force:true})}})\"",

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -1,0 +1,63 @@
+import { expect, test, describe } from "bun:test";
+import { isSafePath, isValidGitKey, isValidSettingValue } from "../electron/security.ts";
+
+// Mocking the environment for security helpers
+const currentCwd = process.cwd();
+
+describe("Security Helpers", () => {
+    describe("isSafePath", () => {
+        test("should allow relative paths inside cwd", () => {
+            expect(isSafePath("src/index.ts", currentCwd)).toBe(true);
+            expect(isSafePath("./README.md", currentCwd)).toBe(true);
+            expect(isSafePath("package.json", currentCwd)).toBe(true);
+        });
+
+        test("should block path traversal", () => {
+            expect(isSafePath("../../../etc/passwd", currentCwd)).toBe(false);
+            // src/../.. escapes currentCwd, so it should be false
+            expect(isSafePath("src/../../package.json", currentCwd)).toBe(false);
+            expect(isSafePath("../../external", currentCwd)).toBe(false);
+        });
+
+        test("should block absolute paths", () => {
+            expect(isSafePath("/etc/passwd", currentCwd)).toBe(false);
+            // On Linux it's relative but we should be careful
+            expect(isSafePath("/var/log/syslog", currentCwd)).toBe(false);
+        });
+    });
+
+    describe("isValidGitKey", () => {
+        test("should allow valid git config keys", () => {
+            expect(isValidGitKey("user.name")).toBe(true);
+            expect(isValidGitKey("core.autocrlf")).toBe(true);
+            expect(isValidGitKey("remote.origin.url")).toBe(true);
+        });
+
+        test("should block keys with special characters", () => {
+            expect(isValidGitKey("user.name; drop table users")).toBe(false);
+            expect(isValidGitKey("core.editor|calc")).toBe(false);
+            expect(isValidGitKey("git config --global user.name")).toBe(false);
+        });
+    });
+
+    describe("isValidSettingValue", () => {
+        test("should allow safe setting values", () => {
+            expect(isValidSettingValue("code")).toBe(true);
+            expect(isValidSettingValue("bash")).toBe(true);
+            expect(isValidSettingValue("powershell.exe")).toBe(true);
+            expect(isValidSettingValue("/usr/bin/vim")).toBe(true);
+        });
+
+        test("should block shell metacharacters", () => {
+            expect(isValidSettingValue("code; rm -rf /")).toBe(false);
+            expect(isValidSettingValue("bash && echo 'pwned'")).toBe(false);
+            expect(isValidSettingValue("editor | nc -e /bin/sh")).toBe(false);
+            expect(isValidSettingValue("$(whoami)")).toBe(false);
+            expect(isValidSettingValue("`id`")).toBe(false);
+        });
+
+        test("should block overly long values", () => {
+            expect(isValidSettingValue("a".repeat(256))).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
This PR hardens the Electron IPC layer against path traversal and shell injection vulnerabilities. 

Key changes:
1.  **Security Utilities:** Introduced `electron/security.ts` containing:
    *   `isSafePath`: Ensures file operations are restricted to the active repository.
    *   `isValidGitKey`: Sanitizes git configuration keys.
    *   `isValidSettingValue`: Prevents shell injection in user settings.
2.  **IPC Hardening:** Integrated these helpers into critical handlers in `electron/main.ts`.
3.  **Testing:** Added a comprehensive test suite `tests/security.test.ts` to verify the validation logic.
4.  **Maintainability:** Refactored the helpers into a separate file to enable direct unit testing without Electron-specific dependencies.

---
*PR created automatically by Jules for task [1781919885458089987](https://jules.google.com/task/1781919885458089987) started by @seanbud*