### PR TITLE
🎨 Palette: Improve dropdown accessibility in RepoHeader

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,5 @@
+# Palette UX Journal
+
+## 2025-05-15 - Improving Dropdown Accessibility in RepoHeader
+**Learning:** Interactive elements implemented as `div` tags with `onClick` are inaccessible to keyboard users and screen readers. Converting these to semantic `<button>` elements with ARIA roles (`listbox`, `option`) and states (`aria-expanded`, `aria-selected`, `aria-haspopup`) provides the necessary structural context.
+**Action:** Always use semantic HTML tags (`<button>`, `<a>`, `<input>`) for interactive elements. Apply style resets like `bg-transparent border-none p-0` and `w-full text-left` to maintain visual consistency when replacing `div` elements.

--- a/components/RepoHeader.tsx
+++ b/components/RepoHeader.tsx
@@ -62,16 +62,19 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
 
   const renderDropdownList = (items: string[], onSelect: (item: string) => void, selectedItem: string, extraItems?: React.ReactNode) => (
     <div className="absolute top-full mt-2 left-0 w-[280px] bg-white rounded-lg shadow-xl border border-gray-200 ring-1 ring-black/5 z-50 overflow-hidden flex flex-col animate-in fade-in slide-in-from-top-1 duration-100">
-      <div className="max-h-[300px] overflow-y-auto py-1">
+      <div className="max-h-[300px] overflow-y-auto py-1" role="listbox">
         {items.map((item) => {
           const isSelected = item === selectedItem;
           const displayName = item.includes('/') || item.includes('\\')
             ? item.replace(/\\/g, '/').split('/').pop() || item
             : item;
           return (
-            <div
+            <button
               key={item}
-              className={`px-4 py-2.5 text-xs font-medium cursor-pointer flex items-center justify-between ${isSelected ? 'bg-gray-100 text-gray-900' : 'hover:bg-gray-50 text-gray-600'}`}
+              type="button"
+              role="option"
+              aria-selected={isSelected}
+              className={`w-full text-left px-4 py-2.5 text-xs font-medium cursor-pointer flex items-center justify-between border-none transition-colors ${isSelected ? 'bg-gray-100 text-gray-900' : 'hover:bg-gray-50 text-gray-600'} focus:outline-none focus:bg-gray-100`}
               onClick={(e) => {
                 e.stopPropagation();
                 onSelect(item);
@@ -80,7 +83,7 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
             >
               <span className="truncate">{displayName}</span>
               {isSelected && <Icons.Check />}
-            </div>
+            </button>
           );
         })}
         {extraItems}
@@ -100,7 +103,11 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
         onContextMenu={(e) => { e.stopPropagation(); onContextMenu(e, 'REPO'); }}
       >
         <button
+          type="button"
           onClick={(e) => handleDropdownClick(e, 'REPO')}
+          aria-haspopup="listbox"
+          aria-expanded={activeDropdown === 'REPO'}
+          aria-label="Select repository"
           className={`flex items-center space-x-2 px-3 py-1.5 rounded-full text-xs font-bold transition-all border shadow-sm active:scale-95 ${repoButtonBg}`}
         >
           <Icons.GitCommit className="w-3.5 h-3.5 opacity-70" />
@@ -113,8 +120,10 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
           state.repoName,
           <>
             <div className="border-t border-gray-100 my-1" />
-            <div
-              className="px-4 py-2.5 text-xs font-medium cursor-pointer hover:bg-gray-50 text-blue-600 flex items-center gap-2"
+            <button
+              type="button"
+              role="option"
+              className="w-full text-left px-4 py-2.5 text-xs font-medium cursor-pointer hover:bg-gray-50 text-blue-600 flex items-center gap-2 border-none bg-transparent focus:outline-none focus:bg-gray-50"
               onClick={(e) => {
                 e.stopPropagation();
                 onOpenRepo?.();
@@ -125,7 +134,7 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
                 <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
               </svg>
               Open Local Repository...
-            </div>
+            </button>
           </>
         )}
       </div>
@@ -137,13 +146,17 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
           onContextMenu={(e) => { e.stopPropagation(); onContextMenu(e, 'BRANCH'); }}
         >
           {/* Branch Name Dropdown Trigger */}
-          <div
+          <button
+            type="button"
             onClick={(e) => handleDropdownClick(e, 'BRANCH')}
-            className={`text-lg md:text-xl font-bold cursor-pointer hover:underline decoration-2 decoration-dotted underline-offset-4 flex items-center ${branchText}`}
+            aria-haspopup="listbox"
+            aria-expanded={activeDropdown === 'BRANCH'}
+            aria-label="Select branch"
+            className={`text-lg md:text-xl font-bold cursor-pointer hover:underline decoration-2 decoration-dotted underline-offset-4 flex items-center bg-transparent border-none p-0 ${branchText} focus:outline-none focus:ring-2 focus:ring-offset-2 ${isPrincess ? 'focus:ring-pink-300' : 'focus:ring-blue-400'} rounded-sm`}
           >
             <Icons.GitBranch className="w-5 h-5 mr-2 opacity-80" />
             <span className="truncate">{state.currentBranch}</span>
-          </div>
+          </button>
 
           {activeDropdown === 'BRANCH' && (
             <div className="absolute top-full left-0 z-50">
@@ -158,8 +171,12 @@ const RepoHeader: React.FC<RepoHeaderProps> = ({
         {/* Comparison Branch Dropdown */}
         <div className="relative">
           <button
+            type="button"
             onClick={(e) => handleDropdownClick(e, 'COMPARE')}
-            className={`bg-gray-200 hover:bg-gray-300 text-gray-700 px-2 py-0.5 rounded text-sm font-mono flex items-center transition-colors border border-transparent hover:border-gray-400 active:scale-95`}
+            aria-haspopup="listbox"
+            aria-expanded={activeDropdown === 'COMPARE'}
+            aria-label="Select comparison branch"
+            className={`bg-gray-200 hover:bg-gray-300 text-gray-700 px-2 py-0.5 rounded text-sm font-mono flex items-center transition-colors border border-transparent hover:border-gray-400 active:scale-95 focus:outline-none focus:ring-2 focus:ring-offset-2 ${isPrincess ? 'focus:ring-pink-300' : 'focus:ring-blue-400'}`}
           >
             {comparisonBranch}
             <span className="ml-1 opacity-50 text-[10px]">▼</span>


### PR DESCRIPTION
🎨 Palette: Improve dropdown accessibility in RepoHeader

This micro-UX improvement enhances the accessibility and keyboard navigability of the repository, branch, and comparison dropdowns in the `RepoHeader` component.

💡 **What:**
- Refactored dropdown triggers and list items to use semantic `<button>` tags instead of `<div>`.
- Added critical ARIA roles and states: `role="listbox"`, `role="option"`, `aria-haspopup`, `aria-expanded`, and `aria-selected`.
- Added descriptive `aria-label` attributes for better screen reader support.
- Implemented focus rings and background states for keyboard navigation.

🎯 **Why:**
Using generic `div` elements with `onClick` handlers creates an inaccessible interface. Screen readers cannot identify these elements as interactive, and they are not reachable via the Tab key. This change ensures that every user can navigate and interact with the repository's primary controls.

♿ **Accessibility:**
- Full keyboard support for header dropdowns.
- Proper structural context for screen readers via ARIA roles.
- High-contrast, theme-aware focus indicators.


---
*PR created automatically by Jules for task [11860109124119959011](https://jules.google.com/task/11860109124119959011) started by @seanbud*