### PR TITLE
🛡️ Sentinel: Harden settings validation to prevent command injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Shell command injection via interpolated strings in `child_process.execSync` within IPC handlers.
 **Learning:** Passing unsanitized strings from the renderer to the main process for shell execution is extremely dangerous. Even quoting arguments is insufficient if the shell interprets special characters or if the input breaks out of quotes.
 **Prevention:** Always use argument arrays with `execFile` or `execFileSync` to bypass the shell entirely. Restrict IPC handlers to specific binaries (e.g., `git`) rather than allowing arbitrary commands.
+
+## 2026-02-24 - Command Injection via Settings
+**Vulnerability:** Unvalidated settings (like `shell` and `externalEditor`) were used as arguments in `execFile` calls, allowing command injection via malicious settings.
+**Learning:** Settings saved by the user are untrusted input. Even when using `execFile` with argument arrays, a malicious binary path or shell name can still lead to arbitrary execution.
+**Prevention:** Implement strict allow-lists for shells and character-set/length validation for path-based settings (e.g., regex: `/^[a-zA-Z0-9._\-\/\\ :~()@+]*$/`). Ensure `app:save-settings` merges and validates sensitive fields rather than blindly overwriting.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -95,6 +95,15 @@ function saveSettings(settings: any) {
     fs.writeFileSync(SETTINGS_PATH, JSON.stringify(settings, null, 2));
 }
 
+function isValidShell(shell: string): boolean {
+    const allowed = ['bash', 'zsh', 'sh', 'fish', 'powershell', 'pwsh', 'cmd'];
+    return allowed.includes(shell.toLowerCase());
+}
+
+function isValidSettingValue(val: any): boolean {
+    return typeof val === 'string' && val.length < 255 && /^[a-zA-Z0-9._\-\/\\ :~()@+]*$/.test(val);
+}
+
 function createWindow() {
     process.env.DIST_ELECTRON = path.join(__dirname, '../dist-electron');
     process.env.DIST = path.join(__dirname, '../dist');
@@ -400,7 +409,10 @@ app.whenReady().then(() => {
 
     ipcMain.handle('shell:open-terminal', async () => {
         const settings = getSettings();
-        const shellCmd = settings.shell || (process.platform === 'win32' ? 'powershell' : 'bash');
+        let shellCmd = settings.shell;
+        if (!shellCmd || !isValidShell(shellCmd)) {
+            shellCmd = process.platform === 'win32' ? 'powershell' : 'bash';
+        }
         try {
             if (process.platform === 'win32') {
                 execFile('cmd.exe', ['/c', 'start', shellCmd], { cwd: currentCwd });
@@ -513,6 +525,17 @@ app.whenReady().then(() => {
     });
 
     ipcMain.handle('app:save-settings', (_, settings) => {
-        saveSettings(settings);
+        const current = getSettings();
+        const updated = { ...current, ...settings };
+
+        // Security: Re-validate sensitive settings if they were provided
+        if (settings.shell && !isValidShell(settings.shell)) {
+            updated.shell = current.shell;
+        }
+        if (settings.externalEditor && !isValidSettingValue(settings.externalEditor)) {
+            updated.externalEditor = current.externalEditor;
+        }
+
+        saveSettings(updated);
     });
 });

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -1,0 +1,47 @@
+import { expect, test, describe } from "bun:test";
+
+/**
+ * Note: These helper functions are duplicated from electron/main.ts for unit testing
+ * because Electron-specific module dependencies make importing directly from main.ts
+ * in a non-Electron environment (like bun test) difficult.
+ */
+function isValidShell(shell: string): boolean {
+    const allowed = ['bash', 'zsh', 'sh', 'fish', 'powershell', 'pwsh', 'cmd'];
+    return allowed.includes(shell.toLowerCase());
+}
+
+function isValidSettingValue(val: any): boolean {
+    return typeof val === 'string' && val.length < 255 && /^[a-zA-Z0-9._\-\/\\ :~()@+]*$/.test(val);
+}
+
+describe("Security Validation Helpers", () => {
+    test("isValidShell should allow permit shells", () => {
+        expect(isValidShell("bash")).toBe(true);
+        expect(isValidShell("zsh")).toBe(true);
+        expect(isValidShell("powershell")).toBe(true);
+        expect(isValidShell("CMD")).toBe(true);
+    });
+
+    test("isValidShell should deny unknown shells", () => {
+        expect(isValidShell("rm -rf /")).toBe(false);
+        expect(isValidShell("curl")).toBe(false);
+        expect(isValidShell("python3")).toBe(false);
+    });
+
+    test("isValidSettingValue should allow safe strings", () => {
+        expect(isValidSettingValue("code")).toBe(true);
+        expect(isValidSettingValue("cursor")).toBe(true);
+        expect(isValidSettingValue("subl")).toBe(true);
+        expect(isValidSettingValue("C:\\Program Files\\VSCode\\bin\\code.exe")).toBe(true);
+        expect(isValidSettingValue("~/bin/cursor")).toBe(true);
+        expect(isValidSettingValue("C:\\Program Files (x86)\\VSCode\\code.exe")).toBe(true);
+        expect(isValidSettingValue("editor@v1.0.0")).toBe(true);
+        expect(isValidSettingValue("path+with+plus")).toBe(true);
+    });
+
+    test("isValidSettingValue should deny dangerous or overly long strings", () => {
+        expect(isValidSettingValue("code; rm -rf /")).toBe(false);
+        expect(isValidSettingValue("a".repeat(300))).toBe(false);
+        expect(isValidSettingValue(null)).toBe(false);
+    });
+});


### PR DESCRIPTION
I have hardened the application against potential command injection vulnerabilities by implementing strict validation for user-configurable settings (`shell` and `externalEditor`) that are used in system command execution.

Key changes:
1.  **Shell Validation:** Implemented `isValidShell` which checks the configured shell against an allow-list (`bash`, `zsh`, `sh`, `fish`, `powershell`, `pwsh`, `cmd`).
2.  **Path Validation:** Implemented `isValidSettingValue` which enforces a 255-character limit and a safe character-set regex (`/^[a-zA-Z0-9._\-\/\\ :~()@+]*$/`) on string settings. This covers common path characters including those used in Windows (like `Program Files (x86)`) and Unix (`~`).
3.  **Harden IPC Handlers:**
    *   `app:save-settings`: Now retrieves current settings and only updates fields if the provided values pass validation, ensuring that invalid settings are rejected and existing settings are not lost.
    *   `shell:open-terminal`: Now validates the configured shell before execution, falling back to platform-appropriate defaults if it's invalid.
4.  **Verification:**
    *   Added a new unit test suite `tests/security.test.ts` to verify the validation helpers in isolation.
    *   Confirmed type safety using `tsc`.
    *   Ensured all tests pass and common path edge cases are handled.
5.  **Documentation:** Recorded critical learnings about the risks of unvalidated user settings in `.jules/sentinel.md`.

This enhancement follows the "Defense in Depth" and "Trust Nothing, Verify Everything" principles, ensuring that even if the renderer process is compromised, the main process remains protected from malicious configuration-based attacks.

---
*PR created automatically by Jules for task [2421116603512988179](https://jules.google.com/task/2421116603512988179) started by @seanbud*