### PR TITLE
🛡️ Sentinel: Harden IPC handlers and prevent path traversal

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Shell command injection via interpolated strings in `child_process.execSync` within IPC handlers.
 **Learning:** Passing unsanitized strings from the renderer to the main process for shell execution is extremely dangerous. Even quoting arguments is insufficient if the shell interprets special characters or if the input breaks out of quotes.
 **Prevention:** Always use argument arrays with `execFile` or `execFileSync` to bypass the shell entirely. Restrict IPC handlers to specific binaries (e.g., `git`) rather than allowing arbitrary commands.
+
+## 2026-03-05 - Insecure IPC Handlers and Path Traversal
+**Vulnerability:** IPC handlers for shell operations and file reading lacked validation, allowing for path traversal and command injection via manipulated settings.
+**Learning:** Even when using safe execution methods like `execFile`, providing unvalidated arguments (like shell paths or editor commands) can lead to vulnerabilities. Logic that handles file paths must be strictly scoped to the intended directory.
+**Prevention:** Centralize security validation logic (e.g., in `utils/security.ts`) and apply it to all IPC handlers. Use path resolution and relative path checks to prevent traversal. Implement allowlists for sensitive values like shells.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { execSync, execFileSync, execFile } from 'child_process';
 import fs from 'fs';
 import { autoUpdater } from 'electron-updater';
+import { isSafePath, isValidShell, isValidSettingValue } from '../utils/security';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -94,6 +95,7 @@ function getSettings() {
 function saveSettings(settings: any) {
     fs.writeFileSync(SETTINGS_PATH, JSON.stringify(settings, null, 2));
 }
+
 
 function createWindow() {
     process.env.DIST_ELECTRON = path.join(__dirname, '../dist-electron');
@@ -400,7 +402,13 @@ app.whenReady().then(() => {
 
     ipcMain.handle('shell:open-terminal', async () => {
         const settings = getSettings();
-        const shellCmd = settings.shell || (process.platform === 'win32' ? 'powershell' : 'bash');
+        let shellCmd = settings.shell || (process.platform === 'win32' ? 'powershell' : 'bash');
+
+        // Security: Validate shell against allowlist
+        if (!isValidShell(shellCmd)) {
+            shellCmd = process.platform === 'win32' ? 'powershell' : 'bash';
+        }
+
         try {
             if (process.platform === 'win32') {
                 execFile('cmd.exe', ['/c', 'start', shellCmd], { cwd: currentCwd });
@@ -414,15 +422,22 @@ app.whenReady().then(() => {
     });
 
     ipcMain.handle('shell:open-path', (_, filePath: string) => {
-        shell.showItemInFolder(filePath);
+        if (isSafePath(filePath, currentCwd)) {
+            shell.showItemInFolder(filePath);
+        }
     });
 
     ipcMain.handle('shell:open-directory', (_, dirPath: string) => {
-        shell.openPath(dirPath);
+        if (isSafePath(dirPath, currentCwd)) {
+            shell.openPath(dirPath);
+        }
     });
 
     ipcMain.handle('shell:trash-item', async (_, filePath: string) => {
-        const fullPath = path.isAbsolute(filePath) ? filePath : path.join(currentCwd, filePath);
+        if (!isSafePath(filePath, currentCwd)) {
+            return { success: false, error: 'Access denied: Path outside of repository' };
+        }
+        const fullPath = path.resolve(currentCwd, filePath);
         try {
             await shell.trashItem(fullPath);
             return { success: true };
@@ -434,12 +449,11 @@ app.whenReady().then(() => {
     // File Preview: read file from disk as base64 data URI
     ipcMain.handle('file:read-base64', (_, relativePath: string) => {
         try {
-            const fullPath = path.resolve(currentCwd, relativePath);
             // Security: Prevent path traversal by ensuring the file is within the repository
-            const relative = path.relative(currentCwd, fullPath);
-            if (relative.startsWith('..') || path.isAbsolute(relative)) {
+            if (!isSafePath(relativePath, currentCwd)) {
                 return { success: false, error: 'Access denied: Path outside of repository' };
             }
+            const fullPath = path.resolve(currentCwd, relativePath);
             if (!fs.existsSync(fullPath)) return { success: false, error: 'File not found' };
             const buffer = fs.readFileSync(fullPath);
             const ext = path.extname(fullPath).toLowerCase();
@@ -513,6 +527,18 @@ app.whenReady().then(() => {
     });
 
     ipcMain.handle('app:save-settings', (_, settings) => {
-        saveSettings(settings);
+        // Security: Validate sensitive settings before saving
+        const finalSettings = { ...getSettings(), ...settings };
+
+        // Ensure critical fields are safe, falling back to current values if invalid
+        if (settings.shell && !isValidShell(settings.shell)) {
+            finalSettings.shell = getSettings().shell;
+        }
+
+        if (settings.externalEditor && !isValidSettingValue(settings.externalEditor)) {
+            finalSettings.externalEditor = getSettings().externalEditor;
+        }
+
+        saveSettings(finalSettings);
     });
 });

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -1,0 +1,62 @@
+import { expect, test, describe } from "bun:test";
+import { isSafePath, isValidShell, isValidSettingValue } from "../utils/security";
+
+const currentCwd = process.cwd();
+
+describe("Security Helpers", () => {
+  describe("isSafePath", () => {
+    test("should allow relative paths within CWD", () => {
+      expect(isSafePath("src/index.ts", currentCwd)).toBe(true);
+      expect(isSafePath("package.json", currentCwd)).toBe(true);
+    });
+
+    test("should block paths outside CWD using ..", () => {
+      expect(isSafePath("../outside.txt", currentCwd)).toBe(false);
+      expect(isSafePath("src/../../outside.txt", currentCwd)).toBe(false);
+    });
+
+    test("should block absolute paths", () => {
+      expect(isSafePath("/etc/passwd", currentCwd)).toBe(false);
+    });
+  });
+
+  describe("isValidShell", () => {
+    test("should allow valid shells", () => {
+      expect(isValidShell("bash")).toBe(true);
+      expect(isValidShell("powershell")).toBe(true);
+      expect(isValidShell("zsh")).toBe(true);
+    });
+
+    test("should block invalid shells", () => {
+      expect(isValidShell("rm -rf /")).toBe(false);
+      expect(isValidShell("node")).toBe(false);
+    });
+  });
+
+  describe("isValidSettingValue", () => {
+    test("should allow safe setting values", () => {
+      expect(isValidSettingValue("code")).toBe(true);
+      expect(isValidSettingValue("subl --wait")).toBe(true);
+      expect(isValidSettingValue("C:\\Program Files\\Editor.exe")).toBe(true);
+    });
+
+    test("should allow quotes in paths", () => {
+      expect(isValidSettingValue('"C:\\Path With Spaces\\editor.exe"')).toBe(true);
+      expect(isValidSettingValue("'C:\\Path With Spaces\\editor.exe'")).toBe(true);
+    });
+
+    test("should block values with dangerous characters", () => {
+      expect(isValidSettingValue("code; rm -rf /")).toBe(false);
+      expect(isValidSettingValue("editor & echo vulnerable")).toBe(false);
+    });
+
+    test("should block redirection and pipes", () => {
+        expect(isValidSettingValue("editor |")).toBe(false);
+        expect(isValidSettingValue("editor >")).toBe(false);
+    });
+
+    test("should block overly long values", () => {
+      expect(isValidSettingValue("a".repeat(256))).toBe(false);
+    });
+  });
+});

--- a/utils/security.ts
+++ b/utils/security.ts
@@ -1,0 +1,18 @@
+import path from 'node:path';
+
+export function isSafePath(filePath: string, currentCwd: string): boolean {
+    const fullPath = path.resolve(currentCwd, filePath);
+    const relative = path.relative(currentCwd, fullPath);
+    return !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+export function isValidShell(shell: string): boolean {
+    const allowlist = ['bash', 'zsh', 'sh', 'fish', 'powershell', 'pwsh', 'cmd'];
+    return allowlist.includes(shell);
+}
+
+export function isValidSettingValue(value: string): boolean {
+    // Basic validation: length limit and character restriction to prevent command injection
+    // Added ' and " to allow for paths with quotes
+    return value.length <= 255 && /^[a-zA-Z0-9._\-\/\\ :~()@+'"]*$/.test(value);
+}


### PR DESCRIPTION
Hardened the Electron IPC handlers against path traversal and command injection by centralizing security validation in a new utility module and applying it to sensitive operations like file system access and terminal execution. Added comprehensive unit tests and updated the security journal.

---
*PR created automatically by Jules for task [17569472371951508150](https://jules.google.com/task/17569472371951508150) started by @seanbud*