### PR TITLE
🎨 Palette: Improve empty state for filtered file list

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -21,3 +21,7 @@
 ## 2025-05-25 - [Accessibility for Toggle Buttons in Diff View]
 **Learning:** Using semantic `<button type="button">` with `aria-expanded` and `aria-label` for chunk headers and context expansion in diff views ensures that complex code-viewing interfaces are navigable for screen reader and keyboard users.
 **Action:** Always use buttons for toggles in the diff view and include `focus:ring-inset` to provide clear focus indicators without layout shifts.
+
+## 2025-05-26 - [Contextual Empty States for Filtered Lists]
+**Learning:** When a list is empty due to active filters, displaying a specific "No matches found" message with a "Clear Filter" action is much more helpful than a generic "No items" message. It prevents user confusion about whether the data exists at all.
+**Action:** Implement contextual empty states that distinguish between globally empty collections and those empty due to user filtering.

--- a/App.tsx
+++ b/App.tsx
@@ -270,6 +270,8 @@ const App: React.FC = () => {
               onHoverStateChange={(state) => !git.isProcessing && git.gitState.selectedFileIds.size === 0 && setCharacterState(state)}
               onContextMenu={handleContextMenu}
               mode={themeMode}
+              isFiltered={!!searchQuery}
+              onClearFilter={() => setSearchQuery('')}
             />
 
             <ActionPanel

--- a/components/FileList.tsx
+++ b/components/FileList.tsx
@@ -112,6 +112,8 @@ interface FileListProps {
   onHoverStateChange: (state: CharacterState) => void;
   onContextMenu: (e: React.MouseEvent, type: 'FILE', payload?: GitFile) => void;
   mode: ThemeMode;
+  isFiltered?: boolean;
+  onClearFilter?: () => void;
 }
 
 const FileList: React.FC<FileListProps> = ({
@@ -120,7 +122,9 @@ const FileList: React.FC<FileListProps> = ({
   onSelectionChange,
   onHoverStateChange,
   onContextMenu,
-  mode
+  mode,
+  isFiltered,
+  onClearFilter
 }) => {
   // Use a ref for lastSelectedId to keep handleSelect stable across renders
   const lastSelectedIdRef = useRef<string | null>(null);
@@ -237,9 +241,25 @@ const FileList: React.FC<FileListProps> = ({
       <div className="flex flex-col min-h-full pb-20 pt-2">
         {files.length === 0 ? (
           <div className="flex flex-col items-center justify-center flex-1 p-10 text-gray-400 text-center">
-            <div className="mb-4 opacity-30 text-4xl">✨</div>
-            <p className="font-medium">No changes found</p>
-            <p className="text-xs mt-1">Your branch is up to date.</p>
+            {isFiltered ? (
+              <>
+                <div className="mb-4 opacity-30 text-4xl">🔍</div>
+                <p className="font-medium text-gray-500">No matches found</p>
+                <p className="text-xs mt-1 mb-4">Try a different filter or clear it.</p>
+                <button
+                  onClick={onClearFilter}
+                  className={`px-4 py-1.5 rounded-full text-xs font-bold transition-all active:scale-95 border ${isPrincess ? 'bg-pink-100 hover:bg-pink-200 text-pink-700 border-pink-200' : 'bg-blue-100 hover:bg-blue-200 text-blue-700 border-blue-200'}`}
+                >
+                  Clear Filter
+                </button>
+              </>
+            ) : (
+              <>
+                <div className="mb-4 opacity-30 text-4xl">✨</div>
+                <p className="font-medium">No changes found</p>
+                <p className="text-xs mt-1">Your branch is up to date.</p>
+              </>
+            )}
           </div>
         ) : (
           <>


### PR DESCRIPTION
This change improves the user experience by providing clear feedback when a file search filter results in no matches. Instead of a generic "No changes found" message, users now see a "No matches found" state with an actionable "Clear Filter" button, making it easier to navigate and recover from over-filtering.

---
*PR created automatically by Jules for task [9544856431710233868](https://jules.google.com/task/9544856431710233868) started by @seanbud*