### PR TITLE
⚡ Bolt: bulk git operations and parallelized state refresh

### DIFF
--- a/hooks/useGitState.ts
+++ b/hooks/useGitState.ts
@@ -63,16 +63,15 @@ export function useGitState(): UseGitStateReturn {
 
     const refreshGitState = useCallback(async () => {
         try {
-            const [repoName, currentBranch, upstreamBranch, config, branchList, commits, settings, bestComp] = await Promise.all([
-                GitService.getRepoName(),
+            // First pass: fetch branch info to reuse in subsequent calls
+            const [currentBranch, upstreamBranch, branchList] = await Promise.all([
                 GitService.getCurrentBranch(),
                 GitService.getUpstreamBranch(),
-                GitService.getGitConfig(),
-                GitService.getBranches(),
-                GitService.getCommitGraph(),
-                GitService.getAppSettings(),
-                GitService.getBestComparisonBranch()
+                GitService.getBranches()
             ]);
+
+            // Determine best comparison branch with pre-fetched info
+            const bestComp = await GitService.getBestComparisonBranch(upstreamBranch, branchList, currentBranch);
 
             // If we don't have a comparison branch set yet, use the best guess
             let activeComp = comparisonBranch;
@@ -81,7 +80,13 @@ export function useGitState(): UseGitStateReturn {
                 setComparisonBranch(bestComp);
             }
 
-            const files = await GitService.getStatusFiles(activeComp);
+            const [repoName, config, commits, settings, files] = await Promise.all([
+                GitService.getRepoName(),
+                GitService.getGitConfig(),
+                GitService.getCommitGraph(),
+                GitService.getAppSettings(),
+                GitService.getStatusFiles(activeComp, currentBranch)
+            ]);
 
             setGitState(prev => ({
                 ...prev,
@@ -205,14 +210,13 @@ export function useGitState(): UseGitStateReturn {
         setCharacterState(actionType === 'RESTORE' ? CharacterState.ACTION_GOOD : CharacterState.ACTION_BAD);
 
         const selectedFiles = gitState.files.filter(f => gitState.selectedFileIds.has(f.id));
+        const paths = selectedFiles.map(f => f.path);
 
         try {
-            for (const file of selectedFiles) {
-                if (actionType === 'RESTORE') {
-                    await GitService.restoreFile(file.path);
-                } else {
-                    await GitService.removeFile(file.path);
-                }
+            if (actionType === 'RESTORE') {
+                await GitService.discardChanges(paths, comparisonBranch);
+            } else {
+                await GitService.removeFiles(paths);
             }
 
             await refreshGitState();

--- a/services/gitService.ts
+++ b/services/gitService.ts
@@ -57,20 +57,25 @@ export class GitService {
         return res.success ? res.stdout.trim() : '';
     }
 
-    static async getBestComparisonBranch(): Promise<string> {
+    static async getBestComparisonBranch(
+        upstream?: string,
+        branches?: string[],
+        currentBranch?: string
+    ): Promise<string> {
         // 1. Try upstream
-        const upstream = await this.getUpstreamBranch();
-        if (upstream) return upstream;
+        const activeUpstream = upstream !== undefined ? upstream : await this.getUpstreamBranch();
+        if (activeUpstream) return activeUpstream;
 
         // 2. Try common branches
         const common = ['develop', 'development', 'main', 'master'];
-        const branches = await this.getBranches();
+        const activeBranches = branches || await this.getBranches();
+
+        const activeCurrent = currentBranch || await this.getCurrentBranch();
 
         for (const target of common) {
-            if (branches.includes(target)) {
+            if (activeBranches.includes(target)) {
                 // Verify it's not the same branch
-                const current = await this.getCurrentBranch();
-                if (current !== target) return target;
+                if (activeCurrent !== target) return target;
             }
         }
 
@@ -81,14 +86,13 @@ export class GitService {
             for (const target of common) {
                 const rTarget = `origin/${target}`;
                 if (remoteBranches.some((rb: string) => rb.includes(rTarget))) {
-                    const current = await this.getCurrentBranch();
-                    if (current !== rTarget) return rTarget;
+                    if (activeCurrent !== rTarget) return rTarget;
                 }
             }
         }
 
         // 4. Fallback to self
-        return await this.getCurrentBranch();
+        return activeCurrent;
     }
 
     static async getBranches(): Promise<string[]> {
@@ -100,15 +104,26 @@ export class GitService {
             .map((b: string) => b.replace('*', '').trim());
     }
 
-    static async getStatusFiles(comparisonBranch?: string): Promise<GitFile[]> {
+    static async getStatusFiles(comparisonBranch?: string, currentBranch?: string): Promise<GitFile[]> {
+        const activeCurrent = currentBranch || await this.getCurrentBranch();
+        const isComparing = comparisonBranch && comparisonBranch !== activeCurrent;
+
+        // Parallelize all git status and diff calls
+        const [statusRes, diffNameRes, localStatsRes, stagedStatsRes, branchStatsRes] = await Promise.all([
+            git('status', '--porcelain'),
+            isComparing ? git('diff', '--name-status', `${comparisonBranch}...HEAD`) : Promise.resolve({ success: false, stdout: '' }),
+            git('diff', '--numstat', '--text'),
+            git('diff', '--numstat', '--text', '--cached'),
+            isComparing ? git('diff', '--numstat', '--text', `${comparisonBranch}...HEAD`) : Promise.resolve({ success: false, stdout: '' })
+        ]);
+
         const files: GitFile[] = [];
         const seenPaths = new Set<string>();
 
-        // 1. Get uncommitted files (Status)
-        const res = await git('status', '--porcelain');
-        if (res.success && res.stdout.trim()) {
-            const lines = res.stdout.split('\n').filter(Boolean);
-            lines.forEach((line: string, index: number) => {
+        // 1. Process uncommitted files (Status)
+        if (statusRes.success && statusRes.stdout.trim()) {
+            const lines = statusRes.stdout.split('\n').filter(Boolean);
+            lines.forEach((line: string) => {
                 const code = line.substring(0, 2);
                 let filePath = line.substring(3).trim();
                 if (filePath.startsWith('"') && filePath.endsWith('"')) {
@@ -132,38 +147,34 @@ export class GitService {
             });
         }
 
-        // 2. Get committed differences if comparing to another branch
-        const currentBranch = await this.getCurrentBranch();
-        if (comparisonBranch && comparisonBranch !== currentBranch) {
-            const diffRes = await git('diff', '--name-status', `${comparisonBranch}...HEAD`);
-            if (diffRes.success && diffRes.stdout.trim()) {
-                const lines = diffRes.stdout.split('\n').filter(Boolean);
-                lines.forEach((line: string, index: number) => {
-                    const parts = line.split(/\s+/);
-                    const code = parts[0];
-                    const filePath = parts[parts.length - 1];
+        // 2. Process committed differences if comparing to another branch
+        if (isComparing && diffNameRes.success && diffNameRes.stdout.trim()) {
+            const lines = diffNameRes.stdout.split('\n').filter(Boolean);
+            lines.forEach((line: string) => {
+                const parts = line.split(/\s+/);
+                const code = parts[0];
+                const filePath = parts[parts.length - 1];
 
-                    // Skip if already seen in status (local changes take priority)
-                    if (seenPaths.has(filePath)) return;
+                // Skip if already seen in status (local changes take priority)
+                if (seenPaths.has(filePath)) return;
 
-                    let status = FileStatus.MODIFIED;
-                    if (code.startsWith('A')) status = FileStatus.ADDED;
-                    if (code.startsWith('D')) status = FileStatus.DELETED;
-                    if (code.startsWith('R')) status = FileStatus.RENAMED;
+                let status = FileStatus.MODIFIED;
+                if (code.startsWith('A')) status = FileStatus.ADDED;
+                if (code.startsWith('D')) status = FileStatus.DELETED;
+                if (code.startsWith('R')) status = FileStatus.RENAMED;
 
-                    files.push({
-                        id: `diff:${filePath}`,
-                        path: filePath,
-                        status,
-                        changeType: ChangeType.COMMITTED,
-                        linesAdded: 0,
-                        linesRemoved: 0
-                    });
+                files.push({
+                    id: `diff:${filePath}`,
+                    path: filePath,
+                    status,
+                    changeType: ChangeType.COMMITTED,
+                    linesAdded: 0,
+                    linesRemoved: 0
                 });
-            }
+            });
         }
 
-        // Fetch line stats
+        // Process line stats
         const statMap = new Map<string, { added: number; removed: number }>();
         const addStats = (stdout: string) => {
             const lines = stdout.split('\n').filter(Boolean);
@@ -182,18 +193,9 @@ export class GitService {
             }
         };
 
-        // 1. Get uncommitted stats (staged + unstaged)
-        // Use separate commands for staged and unstaged to avoid issues with empty repos (no HEAD)
-        const localStats = await git('diff', '--numstat', '--text');
-        if (localStats.success) addStats(localStats.stdout);
-        const stagedStats = await git('diff', '--numstat', '--text', '--cached');
-        if (stagedStats.success) addStats(stagedStats.stdout);
-
-        // 2. Get committed stats for the branch comparison
-        if (comparisonBranch && comparisonBranch !== currentBranch) {
-            const branchStats = await git('diff', '--numstat', '--text', `${comparisonBranch}...HEAD`);
-            if (branchStats.success) addStats(branchStats.stdout);
-        }
+        if (localStatsRes.success) addStats(localStatsRes.stdout);
+        if (stagedStatsRes.success) addStats(stagedStatsRes.stdout);
+        if (isComparing && branchStatsRes.success) addStats(branchStatsRes.stdout);
 
         // Apply stats to files
         for (const file of files) {
@@ -268,8 +270,16 @@ export class GitService {
         return res.success;
     }
 
-    static async discardChanges(filePaths: string[]): Promise<boolean> {
+    static async discardChanges(filePaths: string[], comparisonBranch?: string): Promise<boolean> {
         if (filePaths.length === 0) return true;
+
+        const activeCurrent = await this.getCurrentBranch();
+
+        // If restoring FROM a base branch (making it match the base)
+        if (comparisonBranch && comparisonBranch !== activeCurrent) {
+            const res = await git('checkout', comparisonBranch, '--', ...filePaths);
+            return res.success;
+        }
 
         // 1. Unstage everything in the list
         await git('reset', 'HEAD', '--', ...filePaths);
@@ -285,15 +295,24 @@ export class GitService {
         return restoreRes.success;
     }
 
-    static async removeFile(filePath: string): Promise<boolean> {
+    static async removeFiles(filePaths: string[]): Promise<boolean> {
+        if (filePaths.length === 0) return true;
+
         // 1. Remove from git index first (keep on disk)
         // Use --ignore-unmatch so it doesn't fail if the file is untracked
-        await git('rm', '--cached', '-f', '--ignore-unmatch', filePath);
+        await git('rm', '--cached', '-f', '--ignore-unmatch', ...filePaths);
 
-        // 2. Move the local file to trash/recycle bin
-        // @ts-ignore
-        const res = await window.electronAPI.trashFile(filePath);
-        return res.success;
+        // 2. Move the local files to trash/recycle bin in parallel
+        const results = await Promise.all(
+            // @ts-ignore
+            filePaths.map(path => window.electronAPI.trashFile(path))
+        );
+
+        return results.every(res => res.success);
+    }
+
+    static async removeFile(filePath: string): Promise<boolean> {
+        return this.removeFiles([filePath]);
     }
 
     static async getCommitGraph(): Promise<CommitNode[]> {


### PR DESCRIPTION
Identified and implemented several performance optimizations focusing on reducing Git process spawning overhead and parallelizing independent operations.

💡 What: 
- Refactored `GitService.getStatusFiles` to use `Promise.all` for all its internal Git calls (status, diff --name-status, and numstats).
- Updated `getBestComparisonBranch` and `getStatusFiles` to accept optional pre-fetched branch metadata.
- Refactored `useGitState.refreshGitState` to fetch branch info once and reuse it across multiple concurrent service calls.
- Implemented `GitService.removeFiles` (bulk removal) and extended `GitService.discardChanges` to support bulk restoration from a comparison branch.
- Replaced the sequential file loop in `useGitState.handleAction` with these new bulk operations.

🎯 Why: 
Spawning a separate Git process for every file in a large selection (O(N)) or repeatedly querying the same branch metadata during a refresh cycle caused noticeable UI lag and high CPU spikes. 

📊 Impact: 
- Reduces process spawning for bulk actions from O(N) to O(1) Git commands.
- Significantly speeds up the repository refresh cycle by parallelizing metadata fetching.
- Minimizes redundant CLI execution by hoisting branch discovery.

🔬 Measurement: 
Verified type safety with `pnpm exec tsc --noEmit`. Logic confirmed via code review and manual inspection of optimized code paths.

---
*PR created automatically by Jules for task [5004240781131826643](https://jules.google.com/task/5004240781131826643) started by @seanbud*