### PR TITLE
🛡️ Sentinel: Fix path traversal in Electron IPC handlers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Shell command injection via interpolated strings in `child_process.execSync` within IPC handlers.
 **Learning:** Passing unsanitized strings from the renderer to the main process for shell execution is extremely dangerous. Even quoting arguments is insufficient if the shell interprets special characters or if the input breaks out of quotes.
 **Prevention:** Always use argument arrays with `execFile` or `execFileSync` to bypass the shell entirely. Restrict IPC handlers to specific binaries (e.g., `git`) rather than allowing arbitrary commands.
+
+## 2026-03-14 - Path Traversal in Electron IPC
+**Vulnerability:** IPC handlers (`shell:open-editor`, `shell:trash-item`, `git:show-file-base64`) accepted relative or absolute paths from the renderer without validation, allowing access to files outside the repository.
+**Learning:** Renderer-provided paths must always be validated against a base directory (e.g., the current repository) to prevent escaping the application's intended scope.
+**Prevention:** Use a centralized `isSafePath` utility that combines `path.resolve` and `path.relative` to verify that the final path starts within the allowed base directory.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { execSync, execFileSync, execFile } from 'child_process';
 import fs from 'fs';
 import { autoUpdater } from 'electron-updater';
+import { isSafePath } from '../utils/security';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -390,6 +391,9 @@ app.whenReady().then(() => {
         const settings = getSettings();
         const editor = settings.externalEditor || 'code';
         try {
+            if (!isSafePath(currentCwd, filePath)) {
+                return { success: false, error: 'Access denied: Path outside of repository' };
+            }
             // Security: Use execFile with argument array
             execFile(editor, [filePath], { cwd: currentCwd });
             return { success: true };
@@ -422,6 +426,9 @@ app.whenReady().then(() => {
     });
 
     ipcMain.handle('shell:trash-item', async (_, filePath: string) => {
+        if (!isSafePath(currentCwd, filePath)) {
+            return { success: false, error: 'Access denied: Path outside of repository' };
+        }
         const fullPath = path.isAbsolute(filePath) ? filePath : path.join(currentCwd, filePath);
         try {
             await shell.trashItem(fullPath);
@@ -460,6 +467,9 @@ app.whenReady().then(() => {
     // File Preview: read file from git HEAD as base64 data URI
     ipcMain.handle('git:show-file-base64', (_, relativePath: string) => {
         try {
+            if (!isSafePath(currentCwd, relativePath)) {
+                return { success: false, error: 'Access denied: Path outside of repository' };
+            }
             // Security: Use execFileSync with argument array to prevent command injection
             const result = execFileSync('git', ['show', `HEAD:${relativePath}`], {
                 cwd: currentCwd,

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -1,0 +1,25 @@
+import { expect, test, describe } from "bun:test";
+import { isSafePath } from "../utils/security";
+
+describe("Security Utils", () => {
+    describe("isSafePath", () => {
+        const baseDir = "/home/user/project";
+
+        test("allows relative path inside base", () => {
+            expect(isSafePath(baseDir, "src/index.ts")).toBe(true);
+        });
+
+        test("allows simple file name", () => {
+            expect(isSafePath(baseDir, "README.md")).toBe(true);
+        });
+
+        test("blocks path traversal with ..", () => {
+            expect(isSafePath(baseDir, "../outside.txt")).toBe(false);
+            expect(isSafePath(baseDir, "src/../../outside.txt")).toBe(false);
+        });
+
+        test("blocks absolute paths", () => {
+            expect(isSafePath(baseDir, "/etc/passwd")).toBe(false);
+        });
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,8 @@
     },
     "allowImportingTsExtensions": true,
     "noEmit": true
-  }
+  },
+  "exclude": [
+    "tests"
+  ]
 }

--- a/utils/security.ts
+++ b/utils/security.ts
@@ -1,0 +1,11 @@
+import path from 'node:path';
+
+/**
+ * Validates that a path is safe and stays within a base directory.
+ * Prevents path traversal attacks by ensuring the resolved path starts with the base directory.
+ */
+export function isSafePath(baseDir: string, targetPath: string): boolean {
+    const fullPath = path.resolve(baseDir, targetPath);
+    const relative = path.relative(baseDir, fullPath);
+    return !relative.startsWith('..') && !path.isAbsolute(relative);
+}


### PR DESCRIPTION
This PR hardens the Electron IPC handlers against path traversal attacks. It introduces a centralized isSafePath utility that validates if a given path is within the current repository's working directory. This validation is applied to shell:open-editor, shell:trash-item, and git:show-file-base64 handlers. Unit tests are included to verify the validation logic.

---
*PR created automatically by Jules for task [3628526008798145057](https://jules.google.com/task/3628526008798145057) started by @seanbud*