### PR TITLE
🛡️ Sentinel: Harden IPC handlers against path traversal and command injection

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -4,6 +4,8 @@ import path from 'node:path';
 import { execSync, execFileSync, execFile } from 'child_process';
 import fs from 'fs';
 import { autoUpdater } from 'electron-updater';
+import { isSafePath, isValidShell, isValidSettingValue } from '../utils/security';
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -387,6 +389,9 @@ app.whenReady().then(() => {
     });
 
     ipcMain.handle('shell:open-editor', async (_, filePath: string) => {
+        if (!isSafePath(currentCwd, filePath)) {
+            return { success: false, error: 'Access denied: Path outside of repository' };
+        }
         const settings = getSettings();
         const editor = settings.externalEditor || 'code';
         try {
@@ -414,14 +419,21 @@ app.whenReady().then(() => {
     });
 
     ipcMain.handle('shell:open-path', (_, filePath: string) => {
-        shell.showItemInFolder(filePath);
+        if (isSafePath(currentCwd, filePath)) {
+            shell.showItemInFolder(filePath);
+        }
     });
 
     ipcMain.handle('shell:open-directory', (_, dirPath: string) => {
-        shell.openPath(dirPath);
+        if (isSafePath(currentCwd, dirPath)) {
+            shell.openPath(dirPath);
+        }
     });
 
     ipcMain.handle('shell:trash-item', async (_, filePath: string) => {
+        if (!isSafePath(currentCwd, filePath)) {
+            return { success: false, error: 'Access denied: Path outside of repository' };
+        }
         const fullPath = path.isAbsolute(filePath) ? filePath : path.join(currentCwd, filePath);
         try {
             await shell.trashItem(fullPath);
@@ -434,12 +446,10 @@ app.whenReady().then(() => {
     // File Preview: read file from disk as base64 data URI
     ipcMain.handle('file:read-base64', (_, relativePath: string) => {
         try {
-            const fullPath = path.resolve(currentCwd, relativePath);
-            // Security: Prevent path traversal by ensuring the file is within the repository
-            const relative = path.relative(currentCwd, fullPath);
-            if (relative.startsWith('..') || path.isAbsolute(relative)) {
+            if (!isSafePath(currentCwd, relativePath)) {
                 return { success: false, error: 'Access denied: Path outside of repository' };
             }
+            const fullPath = path.resolve(currentCwd, relativePath);
             if (!fs.existsSync(fullPath)) return { success: false, error: 'File not found' };
             const buffer = fs.readFileSync(fullPath);
             const ext = path.extname(fullPath).toLowerCase();
@@ -460,6 +470,9 @@ app.whenReady().then(() => {
     // File Preview: read file from git HEAD as base64 data URI
     ipcMain.handle('git:show-file-base64', (_, relativePath: string) => {
         try {
+            if (!isSafePath(currentCwd, relativePath)) {
+                return { success: false, error: 'Access denied: Path outside of repository' };
+            }
             // Security: Use execFileSync with argument array to prevent command injection
             const result = execFileSync('git', ['show', `HEAD:${relativePath}`], {
                 cwd: currentCwd,
@@ -513,6 +526,13 @@ app.whenReady().then(() => {
     });
 
     ipcMain.handle('app:save-settings', (_, settings) => {
+        if (settings.shell && !isValidShell(settings.shell)) {
+            return { success: false, error: 'Invalid shell configuration' };
+        }
+        if (settings.externalEditor && !isValidSettingValue(settings.externalEditor)) {
+            return { success: false, error: 'Invalid editor configuration' };
+        }
         saveSettings(settings);
+        return { success: true };
     });
 });

--- a/utils/security.ts
+++ b/utils/security.ts
@@ -1,0 +1,33 @@
+import path from 'node:path';
+
+/**
+ * Validates if a path is safe to access within a base directory.
+ * Prevents path traversal attacks.
+ */
+export function isSafePath(baseDir: string, targetPath: string): boolean {
+    const resolvedPath = path.isAbsolute(targetPath) ? targetPath : path.resolve(baseDir, targetPath);
+    const relative = path.relative(baseDir, resolvedPath);
+    return !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+/**
+ * Validates if a shell path is in the allowlist of common terminal shells.
+ */
+export function isValidShell(shellPath: string): boolean {
+    const commonShells = ['bash', 'zsh', 'sh', 'fish', 'powershell', 'pwsh', 'cmd'];
+    // Normalize backslashes for comparison on Linux hosts when testing Windows paths
+    const normalizedPath = shellPath.replace(/\\/g, '/');
+    const basename = path.basename(normalizedPath).toLowerCase().replace('.exe', '');
+    return commonShells.includes(basename);
+}
+
+/**
+ * Validates a setting value against a character allowlist and length limit.
+ * Helps prevent command injection and other malicious inputs.
+ */
+export function isValidSettingValue(value: string, maxLength: number = 255): boolean {
+    if (typeof value !== 'string' || value.length > maxLength) return false;
+    // Allow alphanumeric, common path characters, and some safe punctuation
+    const safeRegex = /^[a-zA-Z0-9._\-\/\\ :~()@+'"]*$/;
+    return safeRegex.test(value);
+}


### PR DESCRIPTION
Identified several Electron IPC handlers that were vulnerable to path traversal or lacked validation for sensitive user-provided settings. 

I implemented a set of security helpers in `utils/security.ts` to provide robust path validation (ensuring files remain within the repository) and setting validation (restricting shell choices and blocking dangerous characters in command-line arguments). 

The following handlers were hardened:
- `shell:open-editor`, `shell:open-path`, `shell:open-directory`, `shell:trash-item`: Now use `isSafePath` to prevent access to files outside the working directory.
- `file:read-base64`, `git:show-file-base64`: Refactored/Added `isSafePath` checks.
- `app:save-settings`: Now validates the `shell` against an allowlist and the `externalEditor` against a character allowlist to mitigate command injection risks.

Verified the security helpers with `bun test` and confirmed the changes are type-safe with `tsc`.

---
*PR created automatically by Jules for task [11031442991749094572](https://jules.google.com/task/11031442991749094572) started by @seanbud*