### PR TITLE
🎨 Palette: Add copy button to GitHub activation code

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -21,3 +21,7 @@
 ## 2025-05-25 - [Accessibility for Toggle Buttons in Diff View]
 **Learning:** Using semantic `<button type="button">` with `aria-expanded` and `aria-label` for chunk headers and context expansion in diff views ensures that complex code-viewing interfaces are navigable for screen reader and keyboard users.
 **Action:** Always use buttons for toggles in the diff view and include `focus:ring-inset` to provide clear focus indicators without layout shifts.
+
+## 2025-05-26 - [Visual Feedback for Clipboard Actions]
+**Learning:** When implementing 'Copy to Clipboard' functionality, providing immediate visual feedback by temporarily changing the button icon (e.g., to a checkmark) for ~2 seconds significantly improves the user's confidence that the action was successful.
+**Action:** Always pair clipboard actions with a transient success state in the UI to confirm the operation.

--- a/components/SignInModal.tsx
+++ b/components/SignInModal.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useCallback } from 'react';
 import Modal from './Modal';
 import { ThemeMode, GitHubUser } from '../types';
 import { GitHubAuthClient, DeviceCodeResponse } from '../services/githubAuth';
+import { Icons } from '../constants';
 
 function launchConfetti(isPrincess: boolean) {
     const canvas = document.createElement('canvas');
@@ -62,8 +63,20 @@ const SignInModal: React.FC<SignInModalProps> = ({ isOpen, mode, onSuccess }) =>
     const [authData, setAuthData] = useState<DeviceCodeResponse | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [isPolling, setIsPolling] = useState(false);
+    const [copied, setCopied] = useState(false);
 
     const isPrincess = mode === ThemeMode.PRINCESS;
+
+    const handleCopy = async () => {
+        if (!authData) return;
+        try {
+            await navigator.clipboard.writeText(authData.user_code);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        } catch (err) {
+            console.error('Failed to copy code:', err);
+        }
+    };
 
     const startSignIn = async () => {
         try {
@@ -131,10 +144,20 @@ const SignInModal: React.FC<SignInModalProps> = ({ isOpen, mode, onSuccess }) =>
                     </button>
                 ) : (
                     <div className="space-y-4 animate-in fade-in slide-in-from-bottom-2">
-                        <div className={`p-4 rounded-xl border-2 border-dashed ${isPrincess ? 'border-pink-200 bg-pink-50/50' : 'border-slate-700 bg-slate-800/50'}`}>
+                        <div className={`p-4 rounded-xl border-2 border-dashed relative group ${isPrincess ? 'border-pink-200 bg-pink-50/50' : 'border-slate-700 bg-slate-800/50'}`}>
                             <p className="text-xs uppercase font-bold opacity-50 mb-2">Your Activation Code</p>
-                            <div className="text-3xl font-mono tracking-widest font-bold">
-                                {authData.user_code}
+                            <div className="flex items-center justify-center space-x-4">
+                                <div className="text-3xl font-mono tracking-widest font-bold ml-8">
+                                    {authData.user_code}
+                                </div>
+                                <button
+                                    onClick={handleCopy}
+                                    className={`p-2 rounded-md transition-all ${isPrincess ? 'hover:bg-pink-100 text-pink-600' : 'hover:bg-slate-700 text-blue-400'} ${copied ? 'scale-110' : ''}`}
+                                    title="Copy to clipboard"
+                                    aria-label="Copy activation code to clipboard"
+                                >
+                                    {copied ? <Icons.Check className="w-5 h-5" /> : <Icons.Copy className="w-5 h-5" />}
+                                </button>
                             </div>
                         </div>
 

--- a/constants.tsx
+++ b/constants.tsx
@@ -108,6 +108,12 @@ export const Icons = {
     <svg className={props.className} width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
       <polyline points="2 6 4.5 9 10 3"></polyline>
     </svg>
+  ),
+  Copy: ({ className }: { className?: string }) => (
+    <svg className={className} width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+    </svg>
   )
 };
 


### PR DESCRIPTION
This PR adds a "Copy to Clipboard" button to the GitHub device activation code in the `SignInModal`. This micro-UX improvement reduces friction during the authentication process by allowing users to easily copy the code instead of manually transcribing it.

The implementation includes:
- A new `Copy` icon in the global icons constant.
- A transient "copied" state that changes the icon to a checkmark for 2 seconds after a successful copy.
- A semantic `<button>` with a descriptive `aria-label` for screen reader accessibility.
- Theme-aware styling that matches the "Princess" and "Prince" modes.

---
*PR created automatically by Jules for task [5828388784822935482](https://jules.google.com/task/5828388784822935482) started by @seanbud*