### PR TITLE
🎨 Palette: Add copy button for GitHub activation code

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-14 - Copy to Clipboard Feedback Pattern
+**Learning:** Providing immediate visual feedback (e.g., switching to a checkmark icon) after a "Copy to Clipboard" action significantly improves the perceived responsiveness and certainty of the interface.
+**Action:** Always implement a temporary (e.g., 2-second) state change for copy buttons to confirm success.

--- a/components/SignInModal.tsx
+++ b/components/SignInModal.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useCallback } from 'react';
 import Modal from './Modal';
 import { ThemeMode, GitHubUser } from '../types';
 import { GitHubAuthClient, DeviceCodeResponse } from '../services/githubAuth';
+import { Icons } from '../constants';
 
 function launchConfetti(isPrincess: boolean) {
     const canvas = document.createElement('canvas');
@@ -62,6 +63,7 @@ const SignInModal: React.FC<SignInModalProps> = ({ isOpen, mode, onSuccess }) =>
     const [authData, setAuthData] = useState<DeviceCodeResponse | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [isPolling, setIsPolling] = useState(false);
+    const [copied, setCopied] = useState(false);
 
     const isPrincess = mode === ThemeMode.PRINCESS;
 
@@ -131,10 +133,22 @@ const SignInModal: React.FC<SignInModalProps> = ({ isOpen, mode, onSuccess }) =>
                     </button>
                 ) : (
                     <div className="space-y-4 animate-in fade-in slide-in-from-bottom-2">
-                        <div className={`p-4 rounded-xl border-2 border-dashed ${isPrincess ? 'border-pink-200 bg-pink-50/50' : 'border-slate-700 bg-slate-800/50'}`}>
+                        <div className={`p-4 rounded-xl border-2 border-dashed relative group ${isPrincess ? 'border-pink-200 bg-pink-50/50' : 'border-slate-700 bg-slate-800/50'}`}>
                             <p className="text-xs uppercase font-bold opacity-50 mb-2">Your Activation Code</p>
-                            <div className="text-3xl font-mono tracking-widest font-bold">
-                                {authData.user_code}
+                            <div className="text-3xl font-mono tracking-widest font-bold flex items-center justify-center gap-4">
+                                <span>{authData.user_code}</span>
+                                <button
+                                    onClick={() => {
+                                        navigator.clipboard.writeText(authData.user_code);
+                                        setCopied(true);
+                                        setTimeout(() => setCopied(false), 2000);
+                                    }}
+                                    className={`p-2 rounded-lg transition-all ${isPrincess ? 'hover:bg-pink-100 text-pink-600' : 'hover:bg-slate-700 text-blue-400'}`}
+                                    aria-label="Copy activation code"
+                                    title="Copy activation code"
+                                >
+                                    {copied ? <Icons.Check className="w-5 h-5" /> : <Icons.Copy className="w-5 h-5" />}
+                                </button>
                             </div>
                         </div>
 

--- a/constants.tsx
+++ b/constants.tsx
@@ -108,6 +108,12 @@ export const Icons = {
     <svg className={props.className} width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
       <polyline points="2 6 4.5 9 10 3"></polyline>
     </svg>
+  ),
+  Copy: ({ className }: { className?: string }) => (
+    <svg className={className} width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+    </svg>
   )
 };
 


### PR DESCRIPTION
Implemented a micro-UX improvement by adding a "Copy to Clipboard" button for the GitHub device activation code. This reduces friction for the user by allowing them to easily copy the code before navigating to GitHub's authorization page. The implementation includes immediate visual feedback (switching to a checkmark icon for 2 seconds) and adheres to accessibility best practices.

---
*PR created automatically by Jules for task [3671085281885964914](https://jules.google.com/task/3671085281885964914) started by @seanbud*