### PR TITLE
🎨 Palette: Add copy button for GitHub activation code

### DIFF
--- a/components/SignInModal.tsx
+++ b/components/SignInModal.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useCallback } from 'react';
 import Modal from './Modal';
 import { ThemeMode, GitHubUser } from '../types';
 import { GitHubAuthClient, DeviceCodeResponse } from '../services/githubAuth';
+import { Icons } from '../constants';
 
 function launchConfetti(isPrincess: boolean) {
     const canvas = document.createElement('canvas');
@@ -62,8 +63,17 @@ const SignInModal: React.FC<SignInModalProps> = ({ isOpen, mode, onSuccess }) =>
     const [authData, setAuthData] = useState<DeviceCodeResponse | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [isPolling, setIsPolling] = useState(false);
+    const [copied, setCopied] = useState(false);
 
     const isPrincess = mode === ThemeMode.PRINCESS;
+
+    const handleCopy = () => {
+        if (authData?.user_code) {
+            navigator.clipboard.writeText(authData.user_code);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        }
+    };
 
     const startSignIn = async () => {
         try {
@@ -131,10 +141,23 @@ const SignInModal: React.FC<SignInModalProps> = ({ isOpen, mode, onSuccess }) =>
                     </button>
                 ) : (
                     <div className="space-y-4 animate-in fade-in slide-in-from-bottom-2">
-                        <div className={`p-4 rounded-xl border-2 border-dashed ${isPrincess ? 'border-pink-200 bg-pink-50/50' : 'border-slate-700 bg-slate-800/50'}`}>
+                        <div className={`p-4 rounded-xl border-2 border-dashed relative group ${isPrincess ? 'border-pink-200 bg-pink-50/50' : 'border-slate-700 bg-slate-800/50'}`}>
                             <p className="text-xs uppercase font-bold opacity-50 mb-2">Your Activation Code</p>
-                            <div className="text-3xl font-mono tracking-widest font-bold">
-                                {authData.user_code}
+                            <div className="flex items-center justify-center space-x-3">
+                                <div className="text-3xl font-mono tracking-widest font-bold">
+                                    {authData.user_code}
+                                </div>
+                                <button
+                                    onClick={handleCopy}
+                                    title={copied ? "Copied!" : "Copy code"}
+                                    aria-label={copied ? "Code copied to clipboard" : "Copy activation code to clipboard"}
+                                    className={`p-2 rounded-md transition-all active:scale-95 ${isPrincess
+                                        ? (copied ? 'bg-pink-100 text-pink-600' : 'hover:bg-pink-100 text-pink-400 hover:text-pink-600')
+                                        : (copied ? 'bg-blue-900/40 text-blue-400' : 'hover:bg-slate-700 text-slate-400 hover:text-slate-200')
+                                        }`}
+                                >
+                                    {copied ? <Icons.Check /> : <Icons.Copy className="w-5 h-5" />}
+                                </button>
                             </div>
                         </div>
 

--- a/constants.tsx
+++ b/constants.tsx
@@ -98,6 +98,12 @@ export const Icons = {
       <path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.3"/>
     </svg>
   ),
+  Copy: ({ className }: { className?: string }) => (
+    <svg className={className} width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+    </svg>
+  ),
   Search: ({ className }: { className?: string }) => (
      <svg className={className} width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <circle cx="11" cy="11" r="8"></circle>


### PR DESCRIPTION
I have implemented a micro-UX improvement by adding a "Copy Code" button to the GitHub sign-in modal.

Key changes:
- Added a `Copy` icon to `constants.tsx` using an inline SVG.
- Updated `SignInModal.tsx` to include a `copied` state and a `handleCopy` function.
- Integrated the copy button into the activation code display in `SignInModal.tsx`, with theme-specific styling and visual feedback.
- Added an `aria-label` to the button to improve accessibility for screen readers.

I have verified the changes by:
- Running `pnpm exec tsc` and `pnpm exec vite build` to ensure no regressions.
- Creating a Playwright verification script that mocks the Electron API and demonstrates the copy functionality in the browser.
- Capturing a screenshot and video of the new feature in action.

---
*PR created automatically by Jules for task [1086276153593830389](https://jules.google.com/task/1086276153593830389) started by @seanbud*