### PR TITLE
🎨 Palette: Add copy button to GitHub activation code

### DIFF
--- a/components/SignInModal.tsx
+++ b/components/SignInModal.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useCallback } from 'react';
 import Modal from './Modal';
 import { ThemeMode, GitHubUser } from '../types';
 import { GitHubAuthClient, DeviceCodeResponse } from '../services/githubAuth';
+import { Icons } from '../constants';
 
 function launchConfetti(isPrincess: boolean) {
     const canvas = document.createElement('canvas');
@@ -62,8 +63,17 @@ const SignInModal: React.FC<SignInModalProps> = ({ isOpen, mode, onSuccess }) =>
     const [authData, setAuthData] = useState<DeviceCodeResponse | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [isPolling, setIsPolling] = useState(false);
+    const [copied, setCopied] = useState(false);
 
     const isPrincess = mode === ThemeMode.PRINCESS;
+
+    const handleCopy = useCallback(() => {
+        if (authData) {
+            navigator.clipboard.writeText(authData.user_code);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        }
+    }, [authData]);
 
     const startSignIn = async () => {
         try {
@@ -131,11 +141,21 @@ const SignInModal: React.FC<SignInModalProps> = ({ isOpen, mode, onSuccess }) =>
                     </button>
                 ) : (
                     <div className="space-y-4 animate-in fade-in slide-in-from-bottom-2">
-                        <div className={`p-4 rounded-xl border-2 border-dashed ${isPrincess ? 'border-pink-200 bg-pink-50/50' : 'border-slate-700 bg-slate-800/50'}`}>
+                        <div className={`p-4 rounded-xl border-2 border-dashed relative group ${isPrincess ? 'border-pink-200 bg-pink-50/50' : 'border-slate-700 bg-slate-800/50'}`}>
                             <p className="text-xs uppercase font-bold opacity-50 mb-2">Your Activation Code</p>
                             <div className="text-3xl font-mono tracking-widest font-bold">
                                 {authData.user_code}
                             </div>
+                            <button
+                                onClick={handleCopy}
+                                aria-label={copied ? "Code copied" : "Copy activation code"}
+                                className={`absolute top-2 right-2 p-1.5 rounded-md transition-all ${isPrincess
+                                    ? 'hover:bg-pink-100 text-pink-500'
+                                    : 'hover:bg-slate-700 text-blue-400'
+                                    }`}
+                            >
+                                {copied ? <Icons.Check /> : <Icons.Copy />}
+                            </button>
                         </div>
 
                         <div className="text-sm space-y-3">

--- a/constants.tsx
+++ b/constants.tsx
@@ -108,6 +108,12 @@ export const Icons = {
     <svg className={props.className} width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
       <polyline points="2 6 4.5 9 10 3"></polyline>
     </svg>
+  ),
+  Copy: ({ className }: { className?: string }) => (
+    <svg className={className} width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+    </svg>
   )
 };
 


### PR DESCRIPTION
💡 What: Added a "Copy" button next to the GitHub device activation code in the `SignInModal`. The button uses a new `Copy` icon and provides immediate visual feedback by switching to a checkmark for 2 seconds after a successful copy.

🎯 Why: Reduces user friction during the GitHub authentication process by allowing them to quickly copy the code instead of manual selection or transcription.

♿ Accessibility: Added `aria-label` that updates from "Copy activation code" to "Code copied" to provide clear feedback for screen reader users. The button also supports keyboard focus and activation.

✨ Result: A smoother onboarding experience that feels more polished and user-friendly.

---
*PR created automatically by Jules for task [8994173861149225543](https://jules.google.com/task/8994173861149225543) started by @seanbud*