### PR TITLE
🎨 Palette: Add Copy Code button to SignInModal

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-14 - Immediate Feedback for Clipboard Actions
+**Learning:** In the device auth flow, users often struggle with manual code entry. Providing a copy button with immediate visual feedback (checkmark toggle) and accessible label updates significantly reduces friction and cognitive load.
+**Action:** Implement the "Copy-to-Checkmark" pattern for all clipboard-related actions, ensuring `aria-label` is updated to confirm the action for screen reader users.

--- a/components/SignInModal.tsx
+++ b/components/SignInModal.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useCallback } from 'react';
 import Modal from './Modal';
 import { ThemeMode, GitHubUser } from '../types';
 import { GitHubAuthClient, DeviceCodeResponse } from '../services/githubAuth';
+import { Icons } from '../constants';
 
 function launchConfetti(isPrincess: boolean) {
     const canvas = document.createElement('canvas');
@@ -62,6 +63,7 @@ const SignInModal: React.FC<SignInModalProps> = ({ isOpen, mode, onSuccess }) =>
     const [authData, setAuthData] = useState<DeviceCodeResponse | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [isPolling, setIsPolling] = useState(false);
+    const [copied, setCopied] = useState(false);
 
     const isPrincess = mode === ThemeMode.PRINCESS;
 
@@ -131,10 +133,21 @@ const SignInModal: React.FC<SignInModalProps> = ({ isOpen, mode, onSuccess }) =>
                     </button>
                 ) : (
                     <div className="space-y-4 animate-in fade-in slide-in-from-bottom-2">
-                        <div className={`p-4 rounded-xl border-2 border-dashed ${isPrincess ? 'border-pink-200 bg-pink-50/50' : 'border-slate-700 bg-slate-800/50'}`}>
+                        <div className={`p-4 rounded-xl border-2 border-dashed ${isPrincess ? 'border-pink-200 bg-pink-50/50' : 'border-slate-700 bg-slate-800/50'} relative group`}>
                             <p className="text-xs uppercase font-bold opacity-50 mb-2">Your Activation Code</p>
-                            <div className="text-3xl font-mono tracking-widest font-bold">
-                                {authData.user_code}
+                            <div className="text-3xl font-mono tracking-widest font-bold flex items-center justify-center">
+                                <span>{authData.user_code}</span>
+                                <button
+                                    onClick={() => {
+                                        navigator.clipboard.writeText(authData.user_code);
+                                        setCopied(true);
+                                        setTimeout(() => setCopied(false), 2000);
+                                    }}
+                                    aria-label={copied ? "Code copied" : "Copy activation code"}
+                                    className={`ml-4 p-1.5 rounded-md transition-all ${isPrincess ? 'hover:bg-pink-100 text-pink-500' : 'hover:bg-slate-700 text-blue-400'}`}
+                                >
+                                    {copied ? <Icons.Check /> : <Icons.Copy />}
+                                </button>
                             </div>
                         </div>
 

--- a/constants.tsx
+++ b/constants.tsx
@@ -108,6 +108,12 @@ export const Icons = {
     <svg className={props.className} width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
       <polyline points="2 6 4.5 9 10 3"></polyline>
     </svg>
+  ),
+  Copy: (props: { className?: string }) => (
+    <svg className={props.className} width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+    </svg>
   )
 };
 


### PR DESCRIPTION
This PR implements a micro-UX enhancement for the GitHub authentication flow by adding a "Copy to Clipboard" button for the device activation code.

Key changes:
- Added a standard `Copy` icon to the `Icons` object in `constants.tsx`.
- Enhanced `SignInModal.tsx` with a copy button next to the activation code.
- Implemented immediate visual feedback (checkmark icon) and accessible state updates (`aria-label`) upon successful copying.
- Verified the implementation with a Playwright script and visual screenshots.
- Documented the UX pattern in `.jules/palette.md`.

---
*PR created automatically by Jules for task [18320677538523369548](https://jules.google.com/task/18320677538523369548) started by @seanbud*