### PR TITLE
🎨 Palette: Add Copy Code button to Sign In modal and improve accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -21,3 +21,7 @@
 ## 2025-05-25 - [Accessibility for Toggle Buttons in Diff View]
 **Learning:** Using semantic `<button type="button">` with `aria-expanded` and `aria-label` for chunk headers and context expansion in diff views ensures that complex code-viewing interfaces are navigable for screen reader and keyboard users.
 **Action:** Always use buttons for toggles in the diff view and include `focus:ring-inset` to provide clear focus indicators without layout shifts.
+
+## 2026-03-23 - [Accessibility for Icon-Only Buttons and Visual Feedback for Copy]
+**Learning:** Icon-only buttons (like modal close buttons or copy buttons) MUST have descriptive `aria-label` attributes for screen readers. Additionally, providing immediate visual feedback (e.g., changing the icon to a checkmark) and updating the `aria-label` after a copy action significantly improves the user experience.
+**Action:** Ensure all icon-only buttons have `aria-label` and implement immediate visual/ARIA feedback for clipboard actions.

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -59,6 +59,7 @@ const Modal: React.FC<ModalProps> = ({
                         <button
                             onClick={onClose}
                             className={`p-1 rounded-lg hover:bg-black/5 transition-colors ${textClass}`}
+                            aria-label="Close modal"
                         >
                             <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />

--- a/components/SignInModal.tsx
+++ b/components/SignInModal.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useCallback } from 'react';
 import Modal from './Modal';
 import { ThemeMode, GitHubUser } from '../types';
 import { GitHubAuthClient, DeviceCodeResponse } from '../services/githubAuth';
+import { Icons } from '../constants';
 
 function launchConfetti(isPrincess: boolean) {
     const canvas = document.createElement('canvas');
@@ -62,6 +63,7 @@ const SignInModal: React.FC<SignInModalProps> = ({ isOpen, mode, onSuccess }) =>
     const [authData, setAuthData] = useState<DeviceCodeResponse | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [isPolling, setIsPolling] = useState(false);
+    const [copied, setCopied] = useState(false);
 
     const isPrincess = mode === ThemeMode.PRINCESS;
 
@@ -131,11 +133,23 @@ const SignInModal: React.FC<SignInModalProps> = ({ isOpen, mode, onSuccess }) =>
                     </button>
                 ) : (
                     <div className="space-y-4 animate-in fade-in slide-in-from-bottom-2">
-                        <div className={`p-4 rounded-xl border-2 border-dashed ${isPrincess ? 'border-pink-200 bg-pink-50/50' : 'border-slate-700 bg-slate-800/50'}`}>
+                        <div className={`p-4 rounded-xl border-2 border-dashed relative group ${isPrincess ? 'border-pink-200 bg-pink-50/50' : 'border-slate-700 bg-slate-800/50'}`}>
                             <p className="text-xs uppercase font-bold opacity-50 mb-2">Your Activation Code</p>
                             <div className="text-3xl font-mono tracking-widest font-bold">
                                 {authData.user_code}
                             </div>
+                            <button
+                                onClick={() => {
+                                    navigator.clipboard.writeText(authData.user_code);
+                                    setCopied(true);
+                                    setTimeout(() => setCopied(false), 2000);
+                                }}
+                                className={`absolute right-3 bottom-3 p-2 rounded-lg transition-all ${isPrincess ? 'bg-pink-100 text-pink-600 hover:bg-pink-200' : 'bg-slate-700 text-blue-400 hover:bg-slate-600'
+                                    } ${copied ? 'scale-110' : 'hover:scale-105'}`}
+                                aria-label={copied ? "Code copied" : "Copy activation code"}
+                            >
+                                {copied ? <Icons.Check className="w-4 h-4" /> : <Icons.Copy className="w-4 h-4" />}
+                            </button>
                         </div>
 
                         <div className="text-sm space-y-3">

--- a/constants.tsx
+++ b/constants.tsx
@@ -108,6 +108,12 @@ export const Icons = {
     <svg className={props.className} width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
       <polyline points="2 6 4.5 9 10 3"></polyline>
     </svg>
+  ),
+  Copy: ({ className }: { className?: string }) => (
+    <svg className={className} width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+    </svg>
   )
 };
 


### PR DESCRIPTION
Added a "Copy Code" button to the Sign In modal for better UX during GitHub authentication and improved the accessibility of modal close buttons.

---
*PR created automatically by Jules for task [4704617112315042169](https://jules.google.com/task/4704617112315042169) started by @seanbud*