### PR TITLE
🎨 Palette: Add Copy Code button to SignInModal and improve accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -21,3 +21,7 @@
 ## 2025-05-25 - [Accessibility for Toggle Buttons in Diff View]
 **Learning:** Using semantic `<button type="button">` with `aria-expanded` and `aria-label` for chunk headers and context expansion in diff views ensures that complex code-viewing interfaces are navigable for screen reader and keyboard users.
 **Action:** Always use buttons for toggles in the diff view and include `focus:ring-inset` to provide clear focus indicators without layout shifts.
+
+## 2025-03-24 - [Accessible Feedback for Clipboard Actions]
+**Learning:** Providing immediate visual and audible feedback after a clipboard action (like copying an activation code) is crucial for UX. Using a temporary state change (e.g., swapping a "Copy" icon for a "Check" icon) along with updating `aria-label` ensures both sighted and screen-reader users are confirmed of the success.
+**Action:** Implement a 2-second "copied" state with icon toggling and ARIA label updates for all copy-to-clipboard interactions.

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -58,6 +58,7 @@ const Modal: React.FC<ModalProps> = ({
                     {!preventClose && (
                         <button
                             onClick={onClose}
+                            aria-label="Close modal"
                             className={`p-1 rounded-lg hover:bg-black/5 transition-colors ${textClass}`}
                         >
                             <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/components/SignInModal.tsx
+++ b/components/SignInModal.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useCallback } from 'react';
 import Modal from './Modal';
 import { ThemeMode, GitHubUser } from '../types';
 import { GitHubAuthClient, DeviceCodeResponse } from '../services/githubAuth';
+import { Icons } from '../constants';
 
 function launchConfetti(isPrincess: boolean) {
     const canvas = document.createElement('canvas');
@@ -62,6 +63,7 @@ const SignInModal: React.FC<SignInModalProps> = ({ isOpen, mode, onSuccess }) =>
     const [authData, setAuthData] = useState<DeviceCodeResponse | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [isPolling, setIsPolling] = useState(false);
+    const [copied, setCopied] = useState(false);
 
     const isPrincess = mode === ThemeMode.PRINCESS;
 
@@ -131,11 +133,23 @@ const SignInModal: React.FC<SignInModalProps> = ({ isOpen, mode, onSuccess }) =>
                     </button>
                 ) : (
                     <div className="space-y-4 animate-in fade-in slide-in-from-bottom-2">
-                        <div className={`p-4 rounded-xl border-2 border-dashed ${isPrincess ? 'border-pink-200 bg-pink-50/50' : 'border-slate-700 bg-slate-800/50'}`}>
+                        <div className={`p-4 rounded-xl border-2 border-dashed ${isPrincess ? 'border-pink-200 bg-pink-50/50' : 'border-slate-700 bg-slate-800/50'} relative group`}>
                             <p className="text-xs uppercase font-bold opacity-50 mb-2">Your Activation Code</p>
                             <div className="text-3xl font-mono tracking-widest font-bold">
                                 {authData.user_code}
                             </div>
+                            <button
+                                onClick={() => {
+                                    navigator.clipboard.writeText(authData.user_code);
+                                    setCopied(true);
+                                    setTimeout(() => setCopied(false), 2000);
+                                }}
+                                className={`absolute top-2 right-2 p-1.5 rounded-md transition-all ${isPrincess ? 'hover:bg-pink-100 text-pink-500' : 'hover:bg-slate-700 text-blue-400'
+                                    }`}
+                                aria-label={copied ? "Code copied" : "Copy activation code"}
+                            >
+                                {copied ? <Icons.Check /> : <Icons.Copy />}
+                            </button>
                         </div>
 
                         <div className="text-sm space-y-3">

--- a/constants.tsx
+++ b/constants.tsx
@@ -108,6 +108,12 @@ export const Icons = {
     <svg className={props.className} width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
       <polyline points="2 6 4.5 9 10 3"></polyline>
     </svg>
+  ),
+  Copy: ({ className }: { className?: string }) => (
+    <svg className={className} width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+    </svg>
   )
 };
 


### PR DESCRIPTION
💡 What: Added a "Copy Code" button to the GitHub device activation screen in `SignInModal.tsx` and added `aria-label="Close modal"` to the global `Modal.tsx` close button.
🎯 Why: To make the sign-in flow more convenient and the overall app more accessible for screen reader users.
📸 Before/After: See the attached screenshot showing the new copy button in its "copied" state.
♿ Accessibility: Improved by adding descriptive ARIA labels to icon-only buttons in the Modal and SignInModal components.

---
*PR created automatically by Jules for task [3126856707442528847](https://jules.google.com/task/3126856707442528847) started by @seanbud*