### PR TITLE
🎨 Palette: Add copy button to GitHub activation code

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -21,3 +21,7 @@
 ## 2025-05-25 - [Accessibility for Toggle Buttons in Diff View]
 **Learning:** Using semantic `<button type="button">` with `aria-expanded` and `aria-label` for chunk headers and context expansion in diff views ensures that complex code-viewing interfaces are navigable for screen reader and keyboard users.
 **Action:** Always use buttons for toggles in the diff view and include `focus:ring-inset` to provide clear focus indicators without layout shifts.
+
+## 2025-05-26 - [Visual Feedback for Clipboard Operations]
+**Learning:** Providing immediate visual feedback after a clipboard copy operation (e.g., switching from a 'copy' icon to a 'checkmark' icon and updating the `aria-label`) significantly improves the user's confidence that the action was successful.
+**Action:** Implement a temporary "success" state (approx. 2 seconds) with icon and ARIA label updates for all copy-to-clipboard interactions.

--- a/components/SignInModal.tsx
+++ b/components/SignInModal.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useCallback } from 'react';
 import Modal from './Modal';
 import { ThemeMode, GitHubUser } from '../types';
 import { GitHubAuthClient, DeviceCodeResponse } from '../services/githubAuth';
+import { Icons } from '../constants';
 
 function launchConfetti(isPrincess: boolean) {
     const canvas = document.createElement('canvas');
@@ -62,8 +63,17 @@ const SignInModal: React.FC<SignInModalProps> = ({ isOpen, mode, onSuccess }) =>
     const [authData, setAuthData] = useState<DeviceCodeResponse | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [isPolling, setIsPolling] = useState(false);
+    const [copied, setCopied] = useState(false);
 
     const isPrincess = mode === ThemeMode.PRINCESS;
+
+    const handleCopy = useCallback(() => {
+        if (authData?.user_code) {
+            navigator.clipboard.writeText(authData.user_code);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        }
+    }, [authData?.user_code]);
 
     const startSignIn = async () => {
         try {
@@ -131,11 +141,21 @@ const SignInModal: React.FC<SignInModalProps> = ({ isOpen, mode, onSuccess }) =>
                     </button>
                 ) : (
                     <div className="space-y-4 animate-in fade-in slide-in-from-bottom-2">
-                        <div className={`p-4 rounded-xl border-2 border-dashed ${isPrincess ? 'border-pink-200 bg-pink-50/50' : 'border-slate-700 bg-slate-800/50'}`}>
+                        <div className={`p-4 rounded-xl border-2 border-dashed relative group ${isPrincess ? 'border-pink-200 bg-pink-50/50' : 'border-slate-700 bg-slate-800/50'}`}>
                             <p className="text-xs uppercase font-bold opacity-50 mb-2">Your Activation Code</p>
                             <div className="text-3xl font-mono tracking-widest font-bold">
                                 {authData.user_code}
                             </div>
+                            <button
+                                onClick={handleCopy}
+                                aria-label={copied ? "Code copied" : "Copy activation code"}
+                                className={`absolute right-3 top-3 p-2 rounded-lg transition-all ${isPrincess
+                                    ? 'hover:bg-pink-100 text-pink-500'
+                                    : 'hover:bg-slate-700 text-blue-400'
+                                    } ${copied ? 'scale-110' : 'scale-100'}`}
+                            >
+                                {copied ? <Icons.Check className="w-4 h-4" /> : <Icons.Copy className="w-4 h-4" />}
+                            </button>
                         </div>
 
                         <div className="text-sm space-y-3">

--- a/constants.tsx
+++ b/constants.tsx
@@ -108,6 +108,12 @@ export const Icons = {
     <svg className={props.className} width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
       <polyline points="2 6 4.5 9 10 3"></polyline>
     </svg>
+  ),
+  Copy: ({ className }: { className?: string }) => (
+    <svg className={className} width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+    </svg>
   )
 };
 


### PR DESCRIPTION
I have implemented a micro-UX improvement in the GitHub authentication flow.

### 🎨 Palette: Add copy button to GitHub activation code

#### 💡 What
I added a "Copy" button directly next to the GitHub device activation code in the `SignInModal`. This includes a new `Copy` icon in the global icon set and local state management to provide immediate visual feedback.

#### 🎯 Why
During the GitHub device login flow, users are required to copy an 8-character code and paste it into GitHub's website. Manually selecting and copying this text can be cumbersome. The new button simplifies this interaction to a single click.

#### 📸 Verification
I verified the change using a Playwright script that mocks the Electron IPC layer to simulate the authentication flow.
- **Visual Feedback**: When clicked, the button's icon switches to a checkmark for 2 seconds, and its `aria-label` updates to "Code copied".
- **Screenshot**: I've captured a screenshot showing the activation code box with the new button in its "copied" success state.

#### ♿ Accessibility
- Used a semantic `<button>` element to ensure it is keyboard-navigable and focusable.
- Implemented a dynamic `aria-label` that accurately describes the button's purpose and its current state ("Copy activation code" vs. "Code copied").
- The button is placed logically within the tab order, following the activation code text.

#### 🧹 Code Quality
- Added a reusable `Copy` icon to `constants.tsx`.
- The implementation is concise and follows the existing design system and patterns of the repository.
- Verified with `tsc` to ensure no type regressions were introduced.

---
*PR created automatically by Jules for task [202361726308967292](https://jules.google.com/task/202361726308967292) started by @seanbud*