### PR TITLE
🛡️ Sentinel: Security Hardening (Path Traversal & Command Injection Protection)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Shell command injection via interpolated strings in `child_process.execSync` within IPC handlers.
 **Learning:** Passing unsanitized strings from the renderer to the main process for shell execution is extremely dangerous. Even quoting arguments is insufficient if the shell interprets special characters or if the input breaks out of quotes.
 **Prevention:** Always use argument arrays with `execFile` or `execFileSync` to bypass the shell entirely. Restrict IPC handlers to specific binaries (e.g., `git`) rather than allowing arbitrary commands.
+
+## 2026-03-05 - Improper Settings Validation leading to RCE
+**Vulnerability:** User-configurable settings for shell and external editor were persisted without validation, allowing a malicious actor (or a compromised renderer) to point these to arbitrary binaries (e.g., `rm`, `curl`) and achieve Remote Code Execution.
+**Learning:** Even when using `execFile` with argument arrays, if the binary itself is user-controlled, it can still be used for malicious purposes. Settings must be treated as untrusted input.
+**Prevention:** Implement a strict allowlist of approved binaries for shells and editors. Validate settings at both the point of persistence and the point of execution.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,9 +1,10 @@
 import { app, BrowserWindow, shell, ipcMain, safeStorage, dialog, Menu } from 'electron';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
-import { execSync, execFileSync, execFile } from 'child_process';
-import fs from 'fs';
+import { execSync, execFileSync, execFile } from 'node:child_process';
+import fs from 'node:fs';
 import { autoUpdater } from 'electron-updater';
+import { isSafePath, isValidShell } from '../utils/security';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -92,7 +93,24 @@ function getSettings() {
 }
 
 function saveSettings(settings: any) {
-    fs.writeFileSync(SETTINGS_PATH, JSON.stringify(settings, null, 2));
+    const existing = getSettings();
+    const safeSettings = { ...existing };
+
+    // Only allow specific top-level fields and validate them
+    if (typeof settings.shell === 'string' && isValidShell(settings.shell)) {
+        safeSettings.shell = settings.shell;
+    }
+    if (typeof settings.externalEditor === 'string' && isValidShell(settings.externalEditor)) {
+        safeSettings.externalEditor = settings.externalEditor;
+    }
+    if (typeof settings.theme === 'string') {
+        safeSettings.theme = settings.theme;
+    }
+    if (typeof settings.character === 'string') {
+        safeSettings.character = settings.character;
+    }
+
+    fs.writeFileSync(SETTINGS_PATH, JSON.stringify(safeSettings, null, 2));
 }
 
 function createWindow() {
@@ -389,6 +407,11 @@ app.whenReady().then(() => {
     ipcMain.handle('shell:open-editor', async (_, filePath: string) => {
         const settings = getSettings();
         const editor = settings.externalEditor || 'code';
+
+        if (!isValidShell(editor)) {
+            return { success: false, error: 'Invalid editor configured' };
+        }
+
         try {
             // Security: Use execFile with argument array
             execFile(editor, [filePath], { cwd: currentCwd });
@@ -401,6 +424,11 @@ app.whenReady().then(() => {
     ipcMain.handle('shell:open-terminal', async () => {
         const settings = getSettings();
         const shellCmd = settings.shell || (process.platform === 'win32' ? 'powershell' : 'bash');
+
+        if (!isValidShell(shellCmd)) {
+            return { success: false, error: 'Invalid shell configured' };
+        }
+
         try {
             if (process.platform === 'win32') {
                 execFile('cmd.exe', ['/c', 'start', shellCmd], { cwd: currentCwd });
@@ -422,6 +450,9 @@ app.whenReady().then(() => {
     });
 
     ipcMain.handle('shell:trash-item', async (_, filePath: string) => {
+        if (!isSafePath(currentCwd, filePath)) {
+            return { success: false, error: 'Access denied: Path outside of repository' };
+        }
         const fullPath = path.isAbsolute(filePath) ? filePath : path.join(currentCwd, filePath);
         try {
             await shell.trashItem(fullPath);
@@ -434,12 +465,10 @@ app.whenReady().then(() => {
     // File Preview: read file from disk as base64 data URI
     ipcMain.handle('file:read-base64', (_, relativePath: string) => {
         try {
-            const fullPath = path.resolve(currentCwd, relativePath);
-            // Security: Prevent path traversal by ensuring the file is within the repository
-            const relative = path.relative(currentCwd, fullPath);
-            if (relative.startsWith('..') || path.isAbsolute(relative)) {
+            if (!isSafePath(currentCwd, relativePath)) {
                 return { success: false, error: 'Access denied: Path outside of repository' };
             }
+            const fullPath = path.resolve(currentCwd, relativePath);
             if (!fs.existsSync(fullPath)) return { success: false, error: 'File not found' };
             const buffer = fs.readFileSync(fullPath);
             const ext = path.extname(fullPath).toLowerCase();

--- a/utils/security.test.ts
+++ b/utils/security.test.ts
@@ -1,0 +1,76 @@
+import { isSafePath, isValidShell } from './security';
+import path from 'node:path';
+
+// Mock vitest-like testing for bun test
+const describe = (name: string, fn: Function) => {
+  console.log(`\n${name}:`);
+  fn();
+};
+
+const it = (name: string, fn: Function) => {
+  try {
+    fn();
+    console.log(`(pass) ${name}`);
+  } catch (error: any) {
+    console.log(`(fail) ${name}`);
+    throw error;
+  }
+};
+
+const expect = (received: any) => ({
+  toBe: (expected: any) => {
+    if (received !== expected) {
+      throw new Error(`Expected ${expected}, but received ${received}`);
+    }
+  }
+});
+
+describe('isSafePath', () => {
+  const base = '/repo';
+
+  it('allows relative paths within the base', () => {
+    expect(isSafePath(base, 'src/App.tsx')).toBe(true);
+    expect(isSafePath(base, 'package.json')).toBe(true);
+  });
+
+  it('prevents traversal outside the base using ..', () => {
+    expect(isSafePath(base, '../etc/passwd')).toBe(false);
+    expect(isSafePath(base, 'src/../../etc/passwd')).toBe(false);
+  });
+
+  it('prevents absolute paths (on Linux/macOS style)', () => {
+    expect(isSafePath(base, '/etc/passwd')).toBe(false);
+  });
+
+  it('prevents drive-relative paths (Windows style)', () => {
+    expect(isSafePath(base, '\\Windows\\System32')).toBe(false);
+    expect(isSafePath(base, 'C:\\Users\\admin')).toBe(false);
+  });
+});
+
+describe('isValidShell', () => {
+  it('allows binaries from the allowlist', () => {
+    expect(isValidShell('bash')).toBe(true);
+    expect(isValidShell('powershell')).toBe(true);
+    expect(isValidShell('code')).toBe(true);
+    expect(isValidShell('vim')).toBe(true);
+    expect(isValidShell('cursor')).toBe(true);
+  });
+
+  it('allows absolute paths for allowlisted binaries', () => {
+    expect(isValidShell('/usr/bin/bash')).toBe(true);
+    expect(isValidShell('C:\\Program Files\\Microsoft VS Code\\bin\\code.exe')).toBe(true);
+    expect(isValidShell('/usr/local/bin/nvim')).toBe(true);
+  });
+
+  it('rejects binaries not in the allowlist', () => {
+    expect(isValidShell('rm')).toBe(false);
+    expect(isValidShell('curl')).toBe(false);
+    expect(isValidShell('python')).toBe(false);
+    expect(isValidShell('cat')).toBe(false);
+  });
+
+  it('handles empty or null inputs', () => {
+    expect(isValidShell('')).toBe(false);
+  });
+});

--- a/utils/security.ts
+++ b/utils/security.ts
@@ -1,0 +1,39 @@
+import path from 'node:path';
+
+/**
+ * Prevents path traversal by ensuring the resolved path is within the base directory.
+ */
+export function isSafePath(base: string, unsafePath: string): boolean {
+  const normalizedBase = path.normalize(base);
+  const fullPath = path.isAbsolute(unsafePath) ? unsafePath : path.join(normalizedBase, unsafePath);
+  const relative = path.relative(normalizedBase, fullPath);
+
+  // Path is safe if it doesn't start with '..' and is not an absolute path
+  // (on Windows, path.isAbsolute(relative) can be true for drive-relative paths like /temp)
+  // We also explicitly block paths starting with / or \ to handle Windows/Posix mixed environments
+  // or absolute paths like C:\ which might not be caught by isAbsolute on Posix systems.
+  if (unsafePath.startsWith('/') || unsafePath.startsWith('\\') || /^[a-zA-Z]:\\/.test(unsafePath)) {
+    return false;
+  }
+
+  return !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+/**
+ * Validates a shell or editor binary against an allowlist to prevent command injection.
+ */
+export function isValidShell(shellPath: string): boolean {
+  if (!shellPath) return false;
+
+  const allowlist = [
+    'bash', 'zsh', 'sh', 'fish', 'powershell', 'pwsh', 'cmd', 'wsl',
+    'code', 'subl', 'atom', 'idea', 'charm', 'notepad', 'vim', 'nvim', 'emacs', 'nano', 'vi', 'gedit',
+    'vscodium', 'cursor', 'zed'
+  ];
+
+  // Normalize path and get the basename (handling both / and \ separator)
+  const basename = path.basename(shellPath.replace(/\\/g, '/')).toLowerCase();
+  const nameWithoutExe = basename.replace(/\.exe$/, '');
+
+  return allowlist.includes(nameWithoutExe);
+}


### PR DESCRIPTION
🛡️ Sentinel: Security Hardening

🚨 Severity: HIGH
💡 Vulnerability:
1. Path Traversal: IPC handlers for `shell:trash-item` and `file:read-base64` were vulnerable to path traversal if passed crafted relative paths (e.g., `../../../etc/passwd`).
2. Command/Binary Injection: Settings for `shell` and `externalEditor` were persisted without validation, allowing a compromised renderer to point them to arbitrary binaries for execution.

🎯 Impact: Potential information disclosure via file reading and Remote Code Execution (RCE) via malicious configuration.

🔧 Fix:
1. Introduced `utils/security.ts` with `isSafePath` (using `path.relative` and explicit prefix/drive checks) and `isValidShell` (using a binary allowlist).
2. Applied these validations to all relevant IPC handlers in `electron/main.ts`.
3. Implemented strict field validation and merging in `saveSettings` to prevent persistence of unauthorized or malicious settings.
4. Updated built-in imports to use the `node:` prefix for clarity and security.

✅ Verification:
- Added `utils/security.test.ts` and verified with `bun run utils/security.test.ts`.
- Ran type-checking with `pnpm exec tsc` to ensure no regressions or import errors.

---
*PR created automatically by Jules for task [8533353030495727756](https://jules.google.com/task/8533353030495727756) started by @seanbud*